### PR TITLE
Make HttpMethod configurable fix minor issue

### DIFF
--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -91,6 +91,9 @@ public class UploaderModule extends ReactContextBaseJavaModule {
    */
   @ReactMethod
   public void startUpload(ReadableMap options, final Promise promise) {
+
+    String HTTPMethod = "POST";
+
     for (String key : new String[]{"url", "path"}) {
       if (!options.hasKey(key)) {
         promise.reject(new IllegalArgumentException("Missing '" + key + "' field."));
@@ -106,10 +109,15 @@ public class UploaderModule extends ReactContextBaseJavaModule {
       return;
     }
 
+    if (options.hasKey("method") && options.getType("method") == ReadableType.String) {
+        HTTPMethod  = options.getString("method");
+    }
+
     String url = options.getString("url");
     String filePath = options.getString("path");
     try {
       final BinaryUploadRequest request = (BinaryUploadRequest) new BinaryUploadRequest(this.getReactApplicationContext(), url)
+              .setMethod(HTTPMethod)
               .setFileToUpload(filePath)
               .setNotificationConfig(new UploadNotificationConfig())
               .setMaxRetries(2)

--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -40,15 +40,15 @@ RCT_EXPORT_METHOD(getFileInfo:(NSString *)path resolve:(RCTPromiseResolveBlock)r
     @try {
         NSURL *fileUri = [NSURL URLWithString: path];
         NSString *pathWithoutProtocol = [fileUri path];
-
+        
         NSString *name = [fileUri lastPathComponent];
         NSString *extension = [name pathExtension];
         bool exists = [[NSFileManager defaultManager] fileExistsAtPath:pathWithoutProtocol];
         NSMutableDictionary *params = [NSMutableDictionary dictionaryWithObjectsAndKeys: name, @"name", nil];
-
+        
         [params setObject:extension forKey:@"extension"];
         [params setObject:[NSNumber numberWithBool:exists] forKey:@"exists"];
-
+        
         if (exists)
         {
             [params setObject:[self guessMIMETypeFromFileName:name] forKey:@"mimeType"];
@@ -60,7 +60,7 @@ RCT_EXPORT_METHOD(getFileInfo:(NSString *)path resolve:(RCTPromiseResolveBlock)r
                 [params setObject:[NSNumber numberWithLong:fileSize] forKey:@"size"];
             }
         }
-
+        
         resolve(params);
     }
     @catch (NSException *exception) {
@@ -100,11 +100,12 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
     }
     NSString *uploadUrl = options[@"url"];
     NSString *fileURI = options[@"path"];
+    NSString *HTTPMethod = options[@"method"];
     NSDictionary *headers = options[@"headers"];
-
+    
     @try {
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString: uploadUrl]];
-        request.HTTPMethod = @"POST";
+        request.HTTPMethod = HTTPMethod ? HTTPMethod : @"POST";
         [headers enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull val, BOOL * _Nonnull stop) {
             if ([val respondsToSelector:@selector(stringValue)]) {
                 val = [val stringValue];
@@ -124,11 +125,11 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
 }
 
 - (NSURLSession *)urlSession: (int) thisUploadId{
-
+    
     NSURLSessionConfiguration *sessionConfigurationt = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:
                                                         [NSString stringWithFormat:BACKGROUND_SESSION_ID,thisUploadId]];
     _urlSession = [NSURLSession sessionWithConfiguration:sessionConfigurationt delegate:self delegateQueue:nil];
-
+    
     return _urlSession;
 }
 
@@ -145,7 +146,7 @@ didCompleteWithError:(NSError *)error {
     {
         [data setObject:[NSNumber numberWithInteger:response.statusCode] forKey:@"responseCode"];
     }
-
+    
     if (error == nil)
     {
         [self sendEventWithName:@"RNFileUploader-completed" body:data];
@@ -167,7 +168,7 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
     {
         progress = 100.0 * (float)totalBytesSent / (float)totalBytesExpectedToSend;
     }
-
+    
     [self sendEventWithName:@"RNFileUploader-progress" body:@{ @"id": task.taskDescription, @"progress": [NSNumber numberWithFloat:progress] }];
 }
 

--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -23,11 +23,11 @@ static int uploadId = 0;
 
 @synthesize bridge = _bridge;
 
-static NSString *BACKGROUND_SESSION_ID = @"VydiaRNFileUploader";
+static NSString *BACKGROUND_SESSION_ID = @"VydiaRNFileUploader-%i";
 NSURLSession *_urlSession = nil;
 
 - (NSArray<NSString *> *)supportedEvents {
-  return @[@"RNFileUploader-progress", @"RNFileUploader-error", @"RNFileUploader-completed"];
+    return @[@"RNFileUploader-progress", @"RNFileUploader-error", @"RNFileUploader-completed"];
 }
 
 
@@ -37,46 +37,46 @@ NSURLSession *_urlSession = nil;
  */
 RCT_EXPORT_METHOD(getFileInfo:(NSString *)path resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 {
-  @try {
-    NSURL *fileUri = [NSURL URLWithString: path];
-    NSString *pathWithoutProtocol = [fileUri path];
-    
-    NSString *name = [fileUri lastPathComponent];
-    NSString *extension = [name pathExtension];
-    bool exists = [[NSFileManager defaultManager] fileExistsAtPath:pathWithoutProtocol];
-    NSMutableDictionary *params = [NSMutableDictionary dictionaryWithObjectsAndKeys: name, @"name", nil];
+    @try {
+        NSURL *fileUri = [NSURL URLWithString: path];
+        NSString *pathWithoutProtocol = [fileUri path];
 
-    [params setObject:extension forKey:@"extension"];
-    [params setObject:[NSNumber numberWithBool:exists] forKey:@"exists"];
-    
-    if (exists)
-    {
-      [params setObject:[self guessMIMETypeFromFileName:name] forKey:@"mimeType"];
-      NSError* error;
-      NSDictionary<NSFileAttributeKey, id> *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:pathWithoutProtocol error:&error];
-      if (error == nil)
-      {
-        unsigned long long fileSize = [attributes fileSize];
-        [params setObject:[NSNumber numberWithLong:fileSize] forKey:@"size"];
-      }
+        NSString *name = [fileUri lastPathComponent];
+        NSString *extension = [name pathExtension];
+        bool exists = [[NSFileManager defaultManager] fileExistsAtPath:pathWithoutProtocol];
+        NSMutableDictionary *params = [NSMutableDictionary dictionaryWithObjectsAndKeys: name, @"name", nil];
+
+        [params setObject:extension forKey:@"extension"];
+        [params setObject:[NSNumber numberWithBool:exists] forKey:@"exists"];
+
+        if (exists)
+        {
+            [params setObject:[self guessMIMETypeFromFileName:name] forKey:@"mimeType"];
+            NSError* error;
+            NSDictionary<NSFileAttributeKey, id> *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:pathWithoutProtocol error:&error];
+            if (error == nil)
+            {
+                unsigned long long fileSize = [attributes fileSize];
+                [params setObject:[NSNumber numberWithLong:fileSize] forKey:@"size"];
+            }
+        }
+
+        resolve(params);
     }
-
-    resolve(params);
-  }
-  @catch (NSException *exception) {
-    reject(@"RN Uploader", exception.name, nil);
-  }
+    @catch (NSException *exception) {
+        reject(@"RN Uploader", exception.name, nil);
+    }
 }
 
 // Borrowed from http://stackoverflow.com/questions/2439020/wheres-the-iphone-mime-type-database
 - (NSString *)guessMIMETypeFromFileName: (NSString *)fileName {
-  CFStringRef UTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)[fileName pathExtension], NULL);
-  CFStringRef MIMEType = UTTypeCopyPreferredTagWithClass(UTI, kUTTagClassMIMEType);
-  CFRelease(UTI);
-  if (!MIMEType) {
-    return @"application/octet-stream";
-  }
-  return (__bridge NSString *)(MIMEType);
+    CFStringRef UTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)[fileName pathExtension], NULL);
+    CFStringRef MIMEType = UTTypeCopyPreferredTagWithClass(UTI, kUTTagClassMIMEType);
+    CFRelease(UTI);
+    if (!MIMEType) {
+        return @"application/octet-stream";
+    }
+    return (__bridge NSString *)(MIMEType);
 }
 
 
@@ -93,43 +93,43 @@ RCT_EXPORT_METHOD(getFileInfo:(NSString *)path resolve:(RCTPromiseResolveBlock)r
  */
 RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 {
-  int thisUploadId;
-  @synchronized(self.class)
-  {
-    thisUploadId = uploadId++;
-  }
-  NSString *uploadUrl = options[@"url"];
-  NSString *fileURI = options[@"path"];
-  NSDictionary *headers = options[@"headers"];
+    int thisUploadId;
+    @synchronized(self.class)
+    {
+        thisUploadId = uploadId++;
+    }
+    NSString *uploadUrl = options[@"url"];
+    NSString *fileURI = options[@"path"];
+    NSDictionary *headers = options[@"headers"];
 
-  @try {
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString: uploadUrl]];
-    request.HTTPMethod = @"POST";
-    [headers enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull val, BOOL * _Nonnull stop) {
-      if ([val respondsToSelector:@selector(stringValue)]) {
-        val = [val stringValue];
-      }
-      if ([val isKindOfClass:[NSString class]]) {
-        [request setValue:val forHTTPHeaderField:key];
-      }
-    }];
-    NSURLSessionDataTask *uploadTask = [[self urlSession] uploadTaskWithRequest:request fromFile:[NSURL URLWithString: fileURI]];
-    uploadTask.taskDescription = [NSString stringWithFormat:@"%i", thisUploadId];
-    [uploadTask resume];
-    resolve(uploadTask.taskDescription);
-  }
-  @catch (NSException *exception) {
-    reject(@"RN Uploader", exception.name, nil);
-  }
+    @try {
+        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString: uploadUrl]];
+        request.HTTPMethod = @"POST";
+        [headers enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull val, BOOL * _Nonnull stop) {
+            if ([val respondsToSelector:@selector(stringValue)]) {
+                val = [val stringValue];
+            }
+            if ([val isKindOfClass:[NSString class]]) {
+                [request setValue:val forHTTPHeaderField:key];
+            }
+        }];
+        NSURLSessionDataTask *uploadTask = [[self urlSession:thisUploadId] uploadTaskWithRequest:request fromFile:[NSURL URLWithString: fileURI]];
+        uploadTask.taskDescription = [NSString stringWithFormat:@"%i", thisUploadId];
+        [uploadTask resume];
+        resolve(uploadTask.taskDescription);
+    }
+    @catch (NSException *exception) {
+        reject(@"RN Uploader", exception.name, nil);
+    }
 }
 
-- (NSURLSession *)urlSession {
-  if (_urlSession == nil)
-  {
-    NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:BACKGROUND_SESSION_ID];
-    _urlSession = [NSURLSession sessionWithConfiguration:sessionConfiguration delegate:self delegateQueue:nil];
-  }
-  return _urlSession;
+- (NSURLSession *)urlSession: (int) thisUploadId{
+
+    NSURLSessionConfiguration *sessionConfigurationt = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:
+                                                        [NSString stringWithFormat:BACKGROUND_SESSION_ID,thisUploadId]];
+    _urlSession = [NSURLSession sessionWithConfiguration:sessionConfigurationt delegate:self delegateQueue:nil];
+
+    return _urlSession;
 }
 
 
@@ -138,23 +138,23 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
 - (void)URLSession:(NSURLSession *)session
               task:(NSURLSessionTask *)task
 didCompleteWithError:(NSError *)error {
-  NSMutableDictionary *data = [NSMutableDictionary dictionaryWithObjectsAndKeys:task.taskDescription, @"id", nil];
-  NSURLSessionDataTask *uploadTask = (NSURLSessionDataTask *)task;
-  NSHTTPURLResponse *response = (NSHTTPURLResponse *)uploadTask.response;
-  if (response != nil)
-  {
-    [data setObject:[NSNumber numberWithInteger:response.statusCode] forKey:@"responseCode"];
-  }
+    NSMutableDictionary *data = [NSMutableDictionary dictionaryWithObjectsAndKeys:task.taskDescription, @"id", nil];
+    NSURLSessionDataTask *uploadTask = (NSURLSessionDataTask *)task;
+    NSHTTPURLResponse *response = (NSHTTPURLResponse *)uploadTask.response;
+    if (response != nil)
+    {
+        [data setObject:[NSNumber numberWithInteger:response.statusCode] forKey:@"responseCode"];
+    }
 
-  if (error == nil)
-  {
-    [self sendEventWithName:@"RNFileUploader-completed" body:data];
-  }
-  else
-  {
-    [data setObject:error.localizedDescription forKey:@"error"];
-    [self sendEventWithName:@"RNFileUploader-error" body:data];
-  }
+    if (error == nil)
+    {
+        [self sendEventWithName:@"RNFileUploader-completed" body:data];
+    }
+    else
+    {
+        [data setObject:error.localizedDescription forKey:@"error"];
+        [self sendEventWithName:@"RNFileUploader-error" body:data];
+    }
 }
 
 - (void)URLSession:(NSURLSession *)session
@@ -162,13 +162,13 @@ didCompleteWithError:(NSError *)error {
    didSendBodyData:(int64_t)bytesSent
     totalBytesSent:(int64_t)totalBytesSent
 totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
-  float progress = -1;
-  if (totalBytesExpectedToSend > 0) //see documentation.  For unknown size it's -1 (NSURLSessionTransferSizeUnknown)
-  {
-    progress = 100.0 * (float)totalBytesSent / (float)totalBytesExpectedToSend;
-  }
-  
-  [self sendEventWithName:@"RNFileUploader-progress" body:@{ @"id": task.taskDescription, @"progress": [NSNumber numberWithFloat:progress] }];
+    float progress = -1;
+    if (totalBytesExpectedToSend > 0) //see documentation.  For unknown size it's -1 (NSURLSessionTransferSizeUnknown)
+    {
+        progress = 100.0 * (float)totalBytesSent / (float)totalBytesExpectedToSend;
+    }
+
+    [self sendEventWithName:@"RNFileUploader-progress" body:@{ @"id": task.taskDescription, @"progress": [NSNumber numberWithFloat:progress] }];
 }
 
 @end


### PR DESCRIPTION
```
const options = {
    method: 'PUT', //Can now be configured
    url: imageURLSendTo,
    path: imagePath,
    headers: {
      'Content-Type': 'image/jpeg'
    }
  };

Upload.startUpload(options)
```

After reload on iOS listener events were not executed anymore,
due to not unique BACKGROUND_SESSION_ID.