### PR TITLE
add an optional "customUploadId" to the startUpload options

### DIFF
--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -162,7 +162,7 @@ public class UploaderModule extends ReactContextBaseJavaModule {
         }
       }
       String uploadId = request.startUpload();
-      promise.resolve(uploadId);
+      promise.resolve(customUploadId != null ? customUploadId : uploadId);
     } catch (Exception exc) {
       Log.e(TAG, exc.getMessage(), exc);
       promise.reject(exc);

--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -109,6 +109,7 @@ public class UploaderModule extends ReactContextBaseJavaModule {
     String url = options.getString("url");
     String filePath = options.getString("path");
     String method = options.hasKey("method") && options.getType("method") == ReadableType.String ? options.getString("method") : "POST";
+    final String customUploadId = options.hasKey("customUploadId") && options.getType("method") == ReadableType.String ? options.getString("customUploadId") : null;    
     try {
       final BinaryUploadRequest request = (BinaryUploadRequest) new BinaryUploadRequest(this.getReactApplicationContext(), url)
               .setMethod(method)
@@ -119,7 +120,7 @@ public class UploaderModule extends ReactContextBaseJavaModule {
                 @Override
                 public void onProgress(UploadInfo uploadInfo) {
                   WritableMap params = Arguments.createMap();
-                  params.putString("id", uploadInfo.getUploadId());
+                  params.putString("id", customUploadId != null ? customUploadId : uploadInfo.getUploadId());
                   params.putInt("progress", uploadInfo.getProgressPercent()); //0-100
                   sendEvent("progress", params);
                 }
@@ -127,7 +128,7 @@ public class UploaderModule extends ReactContextBaseJavaModule {
                 @Override
                 public void onError(UploadInfo uploadInfo, Exception exception) {
                   WritableMap params = Arguments.createMap();
-                  params.putString("id", uploadInfo.getUploadId());
+                  params.putString("id", customUploadId != null ? customUploadId : uploadInfo.getUploadId());
                   params.putString("error", exception.getMessage());
                   sendEvent("error", params);
                 }
@@ -135,7 +136,7 @@ public class UploaderModule extends ReactContextBaseJavaModule {
                 @Override
                 public void onCompleted(UploadInfo uploadInfo, ServerResponse serverResponse) {
                   WritableMap params = Arguments.createMap();
-                  params.putString("id", uploadInfo.getUploadId());
+                  params.putString("id", customUploadId != null ? customUploadId : uploadInfo.getUploadId());
                   params.putInt("responseCode", serverResponse.getHttpCode());
                   params.putString("responseBody", serverResponse.getBodyAsString());
                   sendEvent("completed", params);
@@ -144,7 +145,7 @@ public class UploaderModule extends ReactContextBaseJavaModule {
                 @Override
                 public void onCancelled(UploadInfo uploadInfo) {
                   WritableMap params = Arguments.createMap();
-                  params.putString("id", uploadInfo.getUploadId());
+                  params.putString("id", customUploadId != null ? customUploadId : uploadInfo.getUploadId());
                   sendEvent("cancelled", params);
                 }
               });

--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -113,6 +113,7 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
     NSString *uploadUrl = options[@"url"];
     NSString *fileURI = options[@"path"];
     NSString *method = options[@"method"];
+    NSString *customUploadId = options[@"customUploadId"];    
     NSDictionary *headers = options[@"headers"];
     
     @try {
@@ -127,7 +128,7 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
             }
         }];
         NSURLSessionDataTask *uploadTask = [[self urlSession:thisUploadId] uploadTaskWithRequest:request fromFile:[NSURL URLWithString: fileURI]];
-        uploadTask.taskDescription = [NSString stringWithFormat:@"%i", thisUploadId];
+        uploadTask.taskDescription = customUploadId ? customUploadId : [NSString stringWithFormat:@"%i", thisUploadId];
         [uploadTask resume];
         resolve(uploadTask.taskDescription);
     }

--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -22,7 +22,7 @@ RCT_EXPORT_MODULE();
 @synthesize bridge = _bridge;
 static int uploadId = 0;
 static RCTEventEmitter* staticEventEmitter = nil;
-static NSString *BACKGROUND_SESSION_ID = @"VydiaRNFileUploader-%i";
+static NSString *BACKGROUND_SESSION_ID = @"VydiaRNFileUploader";
 NSURLSession *_urlSession = nil;
 
 -(id) init {
@@ -138,9 +138,10 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
 
 - (NSURLSession *)urlSession: (int) thisUploadId{
     
-    NSURLSessionConfiguration *sessionConfigurationt = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:
-                                                        [NSString stringWithFormat:BACKGROUND_SESSION_ID,thisUploadId]];
-    _urlSession = [NSURLSession sessionWithConfiguration:sessionConfigurationt delegate:self delegateQueue:nil];
+    if(_urlSession == nil) {
+        NSURLSessionConfiguration *sessionConfigurationt = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:BACKGROUND_SESSION_ID];
+        _urlSession = [NSURLSession sessionWithConfiguration:sessionConfigurationt delegate:self delegateQueue:nil];
+    }
     
     return _urlSession;
 }


### PR DESCRIPTION
Hi @StevePotter,

thank you in advance for considering our pull request.

Motivation: If you are maintaining, for example, an upload queue in a React Native redux store, then it's nice to be able to pass an upload identifier (generated in JS or in the backend or whatever) instead of receiving a generated one. In this case, you can add one global upload listener per event type and just dispatch according redux actions with that upload identifier as payload. The reducer would then be able to match them against the objects in the state. 
However, with this pull request, if you don't pass a "customUploadId" with the startUpload options, everything works like before.

ALSO: On iOS I removed that unnecessary @"VydiaRNFileUploader-%i"; stuff, since this was just a patch for the "events are not passed after JS reload" problem, which I fixed with my last pull request. 
With that @"VydiaRNFileUploader-%i" stuff, your module would create new NSUrlSession each time a JS reload happens. This is a waste of resources AND you are still not getting events for long running uploads, when a JS reload happens while running (at least without my fix).

Best regards,
Rene