### PR TITLE
Add an option to disable Android notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ const options {
   method: 'POST',
   headers: {
     'my-custom-header': 's3headervalueorwhateveryouneed'
+  },
+  // Below are options only supported on Android
+  notification: {
+    enabled: true
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -6,10 +6,15 @@ import { NativeModules, DeviceEventEmitter } from 'react-native'
 
 export type UploadEvent = 'progress' | 'error' | 'completed' | 'cancelled'
 
+export type NotificationArgs = {
+  enabled: boolean
+}
+
 export type StartUploadArgs = {
   url: string,
   path: string,
-  headers?: Object
+  headers?: Object,
+  notification?: NotificationArgs
 }
 
 const NativeModule = NativeModules.VydiaRNFileUploader || NativeModules.RNFileUploader // iOS is VydiaRNFileUploader and Android is NativeModules 
@@ -52,6 +57,8 @@ Options object:
   path: string.  path to the file on the device
   headers: hash of name/value header pairs
   method: HTTP method to use.  Default is "POST"
+  notification: hash for customizing tray notifiaction
+    enabled: boolean to enable/disabled notifications, true by default.
 }
 
 Returns a promise with the string ID of the upload.  Will reject if there is a connection problem, the file doesn't exist, or there is some other problem.


### PR DESCRIPTION
Added an option to disable Android tray notifications.

```
Upload.startUpload({
   // ...
   notification: { 
    enabled: false
  }
})
```

By default notifications are enabled, which means there are no changes which break current behaviour of the library.

The reasoning behind the hash vs boolean option is the following: [android-upload-service](https://github.com/gotev/android-upload-service) which is used by the library supports many other options which allow to customize tray notification ([see their docs](https://github.com/gotev/android-upload-service/wiki/Recipes#notification-configuration)), so I've decided to go with hash in case anyone wills to extend the options to allow customizing these notifications from react-native code. Basically it's for future extendability.