### PR TITLE
Fix iOS build error for missing protocol NSFileAttributeKey

### DIFF
--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -11,6 +11,11 @@
 #import "RCTEventEmitter.h"
 #import "RCTBridgeModule.h"
 
+#ifdef NsFileAttributeKey
+  typedef NsFileAttributeKey UploaderFileAttributeKey;
+#else
+  typedef NSString * UploaderFileAttributeKey;
+#endif
 
 @interface VydiaRNFileUploader : RCTEventEmitter <RCTBridgeModule, NSURLSessionTaskDelegate>
 @end
@@ -65,7 +70,7 @@ RCT_EXPORT_METHOD(getFileInfo:(NSString *)path resolve:(RCTPromiseResolveBlock)r
         {
             [params setObject:[self guessMIMETypeFromFileName:name] forKey:@"mimeType"];
             NSError* error;
-            NSDictionary<NSFileAttributeKey, id> *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:pathWithoutProtocol error:&error];
+            NSDictionary<UploaderFileAttributeKey, id> *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:pathWithoutProtocol error:&error];
             if (error == nil)
             {
                 unsigned long long fileSize = [attributes fileSize];


### PR DESCRIPTION
**Note: Please check if it works in the latest XCode before accepting.**

Build for iOS fails for me with the following error:

> .../react-native-background-upload/ios/VydiaRNFileUploader.m:68:26: No type or protocol named 'NSFileAttributeKey'

There is very little information about this `NSFileAttributeKey` thing in the internet. I've found this piece of code in [CocoaLumberjack repository](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/Classes/DDFileLogger.h#L447)

```
#if FOUNDATION_SWIFT_SDK_EPOCH_AT_LEAST(8)
@property (strong, nonatomic, readonly) NSDictionary<NSFileAttributeKey, id> *fileAttributes;
#else
@property (strong, nonatomic, readonly) NSDictionary<NSString *, id> *fileAttributes;
#endif
```

It makes me think that this `NSFileAttributeKey` type has been added in the latest sdk, but unfortunately I am unable to upgrade to the latest one. I am running XCode 7.3.1.

My fix is somewhat similar to what is used in CocoaLumberjack.

I would be great if anyone could check if my fix works in the latest XCode too.