### PR TITLE
Cancel uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ Upload.startUpload(options).then((uploadId) => {
   Upload.addListener('error', uploadId, (data) => {
     console.log(`Error: ${data.error}%`)
   })
+  Upload.addListener('cancelled', uploadId, (data) => {
+    console.log(`Cancelled!`)
+  })
   Upload.addListener('completed', uploadId, (data) => {
     console.log('Completed!')
   })

--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -188,4 +188,24 @@ public class UploaderModule extends ReactContextBaseJavaModule {
     }
   }
 
+  /*
+   * Cancels file upload
+   * Accepts upload ID as a first argument, this upload will be cancelled
+   * Event "cancelled" will be fired when upload is cancelled.
+   */
+  @ReactMethod
+  public void cancelUpload(String cancelUploadId, final Promise promise) {
+    if (!(cancelUploadId instanceof String)) {
+      promise.reject(new IllegalArgumentException("Upload ID must be a string"));
+      return;
+    }
+    try {
+      UploadService.stopUpload(cancelUploadId);
+      promise.resolve(true);
+    } catch (Exception exc) {
+      Log.e(TAG, exc.getMessage(), exc);
+      promise.reject(exc);
+    }
+  }
+
 }

--- a/index.js
+++ b/index.js
@@ -77,8 +77,16 @@ use it to cancel started upload.
 
 Event "cancelled" will be fired when upload is cancelled.
 
+Returns a promise with boolean true if operation was successfully completed.
+Will reject if there was an internal error or ID format is invalid.
+
 */
-export const cancelUpload = (uploadId: string) => NativeModule.cancelUpload(uploadId)
+export const cancelUpload = (cancelUploadId: string): Promise<boolean> => {
+  if (typeof cancelUploadId !== 'string') {
+    return Promise.reject(new Error('Upload ID must be a string'));
+  }
+  return NativeModule.cancelUpload(cancelUploadId);
+}
 
 /*
 Listens for the given event on the given upload ID (resolved from startUpload).  

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ const eventPrefix = 'RNFileUploader-'
 if (NativeModules.VydiaRNFileUploader) {
   NativeModule.addListener(eventPrefix + 'progress')
   NativeModule.addListener(eventPrefix + 'error')
+  NativeModule.addListener(eventPrefix + 'cancelled')
   NativeModule.addListener(eventPrefix + 'completed')
 }
 
@@ -69,11 +70,23 @@ It is recommended to add listeners in the .then of this promise.
 export const startUpload = (options: StartUploadArgs): Promise<string> => NativeModule.startUpload(options)
 
 /*
+Cancels active upload by string ID of the upload.
+
+Upload ID is returned in a promise after a call to startUpload method,
+use it to cancel started upload.
+
+Event "cancelled" will be fired when upload is cancelled.
+
+*/
+export const cancelUpload = (uploadId: string) => NativeModule.cancelUpload(uploadId)
+
+/*
 Listens for the given event on the given upload ID (resolved from startUpload).  
 If you don't supply a value for uploadId, the event will fire for all uploads.
 Events (id is always the upload ID):
   progress - { id: string, progress: int (0-100) }
   error - { id: string, error: string }
+  cancelled - { id: string, error: string }
   completed - { id: string }
 */
 export const addListener = (eventType: UploadEvent, uploadId: string, listener: Function) => {
@@ -84,4 +97,4 @@ export const addListener = (eventType: UploadEvent, uploadId: string, listener: 
   })
 }
 
-export default { startUpload, addListener, getFileInfo }
+export default { startUpload, cancelUpload, addListener, getFileInfo }

--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -43,7 +43,12 @@ NSURLSession *_urlSession = nil;
 }
 
 - (NSArray<NSString *> *)supportedEvents {
-    return @[@"RNFileUploader-progress", @"RNFileUploader-error", @"RNFileUploader-completed"];
+    return @[
+        @"RNFileUploader-progress",
+        @"RNFileUploader-error",
+        @"RNFileUploader-cancelled",
+        @"RNFileUploader-completed"
+    ];
 }
 
 /*
@@ -130,7 +135,7 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
                 [request setValue:val forHTTPHeaderField:key];
             }
         }];
-        NSURLSessionDataTask *uploadTask = [[self urlSession:thisUploadId] uploadTaskWithRequest:request fromFile:[NSURL URLWithString: fileURI]];
+        NSURLSessionDataTask *uploadTask = [[self urlSession] uploadTaskWithRequest:request fromFile:[NSURL URLWithString: fileURI]];
         uploadTask.taskDescription = customUploadId ? customUploadId : [NSString stringWithFormat:@"%i", thisUploadId];
         [uploadTask resume];
         resolve(uploadTask.taskDescription);
@@ -140,14 +145,29 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
     }
 }
 
-- (NSURLSession *)urlSession: (int) thisUploadId{
+/*
+ * Cancels file upload
+ * Accepts upload ID as a first argument, this upload will be cancelled
+ * Event "cancelled" will be fired when upload is cancelled.
+ */
+RCT_EXPORT_METHOD(cancelUpload: (NSString *)cancelUploadId) {
+    NSURLSession *session = [self urlSession];
+    [session getTasksWithCompletionHandler:^(NSArray *dataTasks, NSArray *uploadTasks, NSArray *downloadTasks) {
+        for (NSURLSessionTask *uploadTask in uploadTasks) {
+            if (uploadTask.taskDescription == cancelUploadId) {
+                [uploadTask cancel];
+            }
+        }
+    }];
+}
+
+- (NSURLSession *)urlSession{
     if(_urlSession == nil) {
         NSURLSessionConfiguration *sessionConfigurationt = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:BACKGROUND_SESSION_ID];
         _urlSession = [NSURLSession sessionWithConfiguration:sessionConfigurationt delegate:self delegateQueue:nil];
     }    
     return _urlSession;
 }
-
 
 #pragma NSURLSessionTaskDelegate
 
@@ -178,7 +198,11 @@ didCompleteWithError:(NSError *)error {
     else
     {
         [data setObject:error.localizedDescription forKey:@"error"];
-        [self _sendEventWithName:@"RNFileUploader-error" body:data];
+        if (error.code == NSURLErrorCancelled) {
+            [self _sendEventWithName:@"RNFileUploader-cancelled" body:data];
+        } else {
+            [self _sendEventWithName:@"RNFileUploader-error" body:data];
+        }
     }
 }
 

--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -150,7 +150,7 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
  * Accepts upload ID as a first argument, this upload will be cancelled
  * Event "cancelled" will be fired when upload is cancelled.
  */
-RCT_EXPORT_METHOD(cancelUpload: (NSString *)cancelUploadId) {
+RCT_EXPORT_METHOD(cancelUpload: (NSString *)cancelUploadId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     NSURLSession *session = [self urlSession];
     [session getTasksWithCompletionHandler:^(NSArray *dataTasks, NSArray *uploadTasks, NSArray *downloadTasks) {
         for (NSURLSessionTask *uploadTask in uploadTasks) {
@@ -159,6 +159,7 @@ RCT_EXPORT_METHOD(cancelUpload: (NSString *)cancelUploadId) {
             }
         }
     }];
+    resolve([NSNumber numberWithBool:YES]);
 }
 
 - (NSURLSession *)urlSession{


### PR DESCRIPTION
Adds a method for cancelling active upload by upload ID.
Fires an event "cancelled" with ID of the cancelled upload.
Method returns a promise with boolean whether cancel was executed successfully or not.

I've changed a bit how customUploadId is handled on Android, `BinaryUploadRequest` from `android-upload-service` also accepts a custom ID for upload. (http://gotev.github.io/android-upload-service/javadoc/) , constructors:

```
BinaryUploadRequest(Context context, String serverUrl)
BinaryUploadRequest(Context context, String uploadId, String serverUrl)
```

so in order to be able to cancel an upload by id, `android-upload-service` should also be aware of this id. I am using second constructor definition to pass a custom id to the service.
