### PR TITLE
Updated react-native peer dependencies version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "peerDependencies": {
     "react": "*",
-    "react-native": ">=0.30.0 <0.39.0"
+    "react-native": ">=0.40.0"
   },
   "author": "Steve Potter",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
1.0.0 now supports RN 0.40.0+. Updated peer dependencies to reflect the correct `react-native` versions.