### PR TITLE
Prevent Android out of memory error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,5 +32,6 @@ repositories {
 }
 dependencies {
     compile 'net.gotev:uploadservice:3.2.3'
+    compile 'net.gotev:uploadservice-okhttp:3.2.3'
     compile 'com.facebook.react:react-native:+'
 }

--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -23,6 +23,7 @@ import net.gotev.uploadservice.UploadInfo;
 import net.gotev.uploadservice.UploadNotificationConfig;
 import net.gotev.uploadservice.UploadService;
 import net.gotev.uploadservice.UploadStatusDelegate;
+import net.gotev.uploadservice.okhttp.OkHttpStack;
 
 import java.io.File;
 
@@ -35,6 +36,7 @@ public class UploaderModule extends ReactContextBaseJavaModule {
   public UploaderModule(ReactApplicationContext reactContext) {
     super(reactContext);
     UploadService.NAMESPACE = reactContext.getApplicationInfo().packageName;
+    UploadService.HTTP_STACK = new OkHttpStack();
   }
 
   @Override


### PR DESCRIPTION
We were getting an out of memory crash on our Android app.  This PR fixes that.

https://github.com/gotev/android-upload-service/issues/159
https://github.com/gotev/android-upload-service/wiki/Setup#use-custom-http-stack