### PR TITLE
Use okhttp in Android to fix crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,29 +54,6 @@ The only React Native http post file uploader with android and iOS background su
 4. Ensure Android SDK versions.  Open your app's `android/app/build.gradle` file.  Ensure `compileSdkVersion` and `targetSdkVersion` are 25.  Otherwise you'll get compilation errors.
 
 
-## BREAKING CHANGE IN 2.0
-Two big things happened in version 2.0.  First, thehe Android package name had to be changed, as it conflicted with our own internal app.  My bad.  Second, we updated the android upload service dependency to the latest, but that requires the app have a compileSdkVersion and targetSdkVersion or 25.
-
-To upgrade:
-In `MainApplication.java`:
-
-Change
-
-    ```java
-    import com.vydia.UploaderReactPackage;
-    ```
-
-to
-
-    ```java
-    import com.vydia.RNUploader.UploaderReactPackage;
-    ```
-    
-Then open your app's `android/app/build.gradle` file.
-Ensure `compileSdkVersion` and `targetSdkVersion` are 25.
-
-Done!
-
 ## Usage
 
 ```js
@@ -124,6 +101,41 @@ Does it support multiple file uploads?
 Why should I use this file uploader instead of others that I've Googled like [react-native-uploader](https://github.com/aroth/react-native-uploader)?
 
 > This package has two killer features not found anywhere else (as of 12/16/2016).  First, it works on both iOS and Android.  Others are iOS only.  Second, it supports background uploading.  This means that users can background your app and the upload will continue.  This does not happen with other uploaders.
+
+
+## BREAKING CHANGE IN 3.0
+In 3.0, you need to add 
+```gradle
+    configurations.all { resolutionStrategy.force 'com.squareup.okhttp3:okhttp:3.4.1' }
+```
+to your app's app's `android/app/build.gradle` file.
+
+Just add it above (not within) `dependencies` and you'll be fine.
+
+
+## BREAKING CHANGE IN 2.0
+Two big things happened in version 2.0.  First, thehe Android package name had to be changed, as it conflicted with our own internal app.  My bad.  Second, we updated the android upload service dependency to the latest, but that requires the app have a compileSdkVersion and targetSdkVersion or 25.
+
+To upgrade:
+In `MainApplication.java`:
+
+Change
+
+    ```java
+    import com.vydia.UploaderReactPackage;
+    ```
+
+to
+
+    ```java
+    import com.vydia.RNUploader.UploaderReactPackage;
+    ```
+    
+Then open your app's `android/app/build.gradle` file.
+Ensure `compileSdkVersion` and `targetSdkVersion` are 25.
+
+Done!
+
 
 ## Gratitude
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,6 @@ The only React Native http post file uploader with android and iOS background su
     include ':react-native-background-upload'
     project(':react-native-background-upload').projectDir = new File(settingsDir, '../node_modules/react-native-background-upload/android')
     ```
-2. Add the compile line to the dependencies in `android/app/build.gradle`:
-
-    ```gradle
-    dependencies {
-        compile project(':react-native-background-upload')
-    }
-    ```
 2. Add the compile and resolutionStrategy line to the dependencies in `android/app/build.gradle`:
 
     ```gradle

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The only React Native http post file uploader with android and iOS background su
 2. Add the compile and resolutionStrategy line to the dependencies in `android/app/build.gradle`:
 
     ```gradle
-    configurations.all { resolutionStrategy.force 'com.squareup.okhttp3:okhttp:3.4.1' } // required until React Native supports okhttp >= okhttp 3.5
+    configurations.all { resolutionStrategy.force 'com.squareup.okhttp3:okhttp:3.4.1' } // required by react-native-background-upload until React Native supports okhttp >= okhttp 3.5
 
     dependencies {
         compile project(':react-native-background-upload')

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ The only React Native http post file uploader with android and iOS background su
         compile project(':react-native-background-upload')
     }
     ```
+2. Add the compile and resolutionStrategy line to the dependencies in `android/app/build.gradle`:
+
+    ```gradle
+    configurations.all { resolutionStrategy.force 'com.squareup.okhttp3:okhttp:3.4.1' } // required until React Native supports okhttp >= okhttp 3.5
+
+    dependencies {
+        compile project(':react-native-background-upload')
+    }
+    ```
+
+
 3. Add the import and link the package in `MainApplication.java`:
 
     ```java

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,6 +31,18 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile 'net.gotev:uploadservice:3.2.3'
+    /**
+     * These versions are hard-coded because otherwise you get
+     * a RN compilation error java.util.zip.ZipException: duplicate entry: okhttp3/internal/ws/RealWebSocket$1.class
+     * This is due to a way okhttp changed in 3.5.  UploadService uses 3.+, which
+     * resolved the library to 3.7.  Long story short, it broke and this fixes it.  These 3 libs should be kept in sync
+     * with React Native, and could be removed later on if apps start compiling.  RN uses
+     * https://github.com/facebook/react-native/blob/master/ReactAndroid/build.gradle
+     * https://github.com/facebook/react-native/issues/12646
+     */
+//    compile ('com.squareup.okhttp3:okhttp:3.4.1') { force = true }
+ //   compile ('com.squareup.okhttp3:okhttp-urlconnection:3.4.1') { force = true }
+ //   compile ('com.squareup.okhttp3:okhttp-ws:3.4.1') { force = true }
     compile 'com.facebook.react:react-native:+'
+    compile 'net.gotev:uploadservice-okhttp:3.2.3'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,17 +32,13 @@ repositories {
 }
 dependencies {
     /**
-     * These versions are hard-coded because otherwise you get
-     * a RN compilation error java.util.zip.ZipException: duplicate entry: okhttp3/internal/ws/RealWebSocket$1.class
-     * This is due to a way okhttp changed in 3.5.  UploadService uses 3.+, which
-     * resolved the library to 3.7.  Long story short, it broke and this fixes it.  These 3 libs should be kept in sync
-     * with React Native, and could be removed later on if apps start compiling.  RN uses
-     * https://github.com/facebook/react-native/blob/master/ReactAndroid/build.gradle
-     * https://github.com/facebook/react-native/issues/12646
-     */
-//    compile ('com.squareup.okhttp3:okhttp:3.4.1') { force = true }
- //   compile ('com.squareup.okhttp3:okhttp-urlconnection:3.4.1') { force = true }
- //   compile ('com.squareup.okhttp3:okhttp-ws:3.4.1') { force = true }
+     * Using okhttp is better because it fixes a possible outofmemory exception.
+     * However the okhttp library can have a funky version resolution and cause compilation errors with RN
+     * There is a PR to fix that
+     * https://github.com/facebook/react-native/pull/11835
+     * Until that is merged and RN is upgraded, you need to add this line to your android/app/build.gradle, inside 'android' block:
+     * configurations.all { resolutionStrategy.force 'com.squareup.okhttp3:okhttp:3.4.1' }
+    */
     compile 'com.facebook.react:react-native:+'
     compile 'net.gotev:uploadservice-okhttp:3.2.3'
 }

--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -23,6 +23,7 @@ import net.gotev.uploadservice.UploadInfo;
 import net.gotev.uploadservice.UploadNotificationConfig;
 import net.gotev.uploadservice.UploadService;
 import net.gotev.uploadservice.UploadStatusDelegate;
+import net.gotev.uploadservice.okhttp.OkHttpStack;
 
 import java.io.File;
 
@@ -35,6 +36,7 @@ public class UploaderModule extends ReactContextBaseJavaModule {
   public UploaderModule(ReactApplicationContext reactContext) {
     super(reactContext);
     UploadService.NAMESPACE = reactContext.getApplicationInfo().packageName;
+    UploadService.HTTP_STACK = new OkHttpStack();
   }
 
   @Override

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-background-upload",
-  "version": "2.1.1",
+  "version": "3.0.0-beta",
   "description": "Cross platform http post file uploader with android and iOS background support",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We were getting an out of memory crash on our Android app.  This PR fixes that.

https://github.com/gotev/android-upload-service/issues/159
https://github.com/gotev/android-upload-service/wiki/Setup#use-custom-http-stack

This results in a compilation error when upgrading.  As a result, you must add this line above 'dependencies' in app/build.grade:
`configurations.all { resolutionStrategy.force 'com.squareup.okhttp3:okhttp:3.4.1' }`

Why?  Because React Native uses okhttp 3.4.1 and the uploader service resolves okhttp 3.+.  Left alone, this results in a compilation error.  I could not find a way to force the resolution within the package's build.gradle, and it could only be done at the app level.  This sucks but it's just one line.

More info on the RN/okhttp issue:
https://github.com/facebook/react-native/blob/master/ReactAndroid/build.gradle
https://github.com/facebook/react-native/issues/12646




