### PR TITLE
Remove iOS console warning and cleanup .m file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-background-upload",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Cross platform http post file uploader with android and iOS background support",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Cleaned up comments, unused parameters, and variable typos.  But most importantly I added `requiresMainQueueSetup` which stops a console warning in RN 49+.