### PR TITLE
Support iOS assets-library url

### DIFF
--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -57,12 +57,10 @@ RCT_EXPORT_METHOD(getFileInfo:(NSString *)path resolve:(RCTPromiseResolveBlock)r
     @try {
         NSURL *fileUri = [NSURL URLWithString: path];
         NSString *pathWithoutProtocol = [fileUri path];
-
         NSString *name = [fileUri lastPathComponent];
         NSString *extension = [name pathExtension];
         bool exists = [[NSFileManager defaultManager] fileExistsAtPath:pathWithoutProtocol];
         NSMutableDictionary *params = [NSMutableDictionary dictionaryWithObjectsAndKeys: name, @"name", nil];
-
         [params setObject:extension forKey:@"extension"];
         [params setObject:[NSNumber numberWithBool:exists] forKey:@"exists"];
 
@@ -77,7 +75,6 @@ RCT_EXPORT_METHOD(getFileInfo:(NSString *)path resolve:(RCTPromiseResolveBlock)r
                 [params setObject:[NSNumber numberWithLong:fileSize] forKey:@"size"];
             }
         }
-
         resolve(params);
     }
     @catch (NSException *exception) {

--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -287,7 +287,6 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
     {
         progress = 100.0 * (float)totalBytesSent / (float)totalBytesExpectedToSend;
     }
-
     [self _sendEventWithName:@"RNFileUploader-progress" body:@{ @"id": task.taskDescription, @"progress": [NSNumber numberWithFloat:progress] }];
 }
 

--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -147,7 +147,7 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
             NSString *pathToWrite = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
             NSURL *pathUrl = [NSURL fileURLWithPath:pathToWrite];
             fileURI = pathUrl.absoluteString;
-            
+
             PHAssetResourceRequestOptions *options = [PHAssetResourceRequestOptions new];
             options.networkAccessAllowed = YES;
 
@@ -165,7 +165,7 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
                 return;
             }
         }
-        
+
         NSURLSessionDataTask *uploadTask;
 
         if ([uploadType isEqualToString:@"multipart"]) {
@@ -180,7 +180,7 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
         } else {
             uploadTask = [[self urlSession] uploadTaskWithRequest:request fromFile:[NSURL URLWithString: fileURI]];
         }
-    
+
         uploadTask.taskDescription = customUploadId ? customUploadId : [NSString stringWithFormat:@"%i", thisUploadId];
 
         [uploadTask resume];
@@ -218,7 +218,6 @@ RCT_EXPORT_METHOD(cancelUpload: (NSString *)cancelUploadId resolve:(RCTPromiseRe
     NSString *pathWithoutProtocol = [fileUri path];
 
     NSData *data = [[NSFileManager defaultManager] contentsAtPath:pathWithoutProtocol];
-
     NSString *filename  = [path lastPathComponent];
     NSString *mimetype  = [self guessMIMETypeFromFileName:path];
 

--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -138,11 +138,39 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
             }
         }];
 
-        __block NSURLSessionDataTask *uploadTask;
+        // asset library files have to be copied over to a temp file.  they cannot be uploaded directly
+        if ([fileURI hasPrefix:@"assets-library"]) {
+            NSURL *url = [NSURL URLWithString:fileURI];
+            PHAsset *asset = [PHAsset fetchAssetsWithALAssetURLs:@[url] options:nil].lastObject;
+            if (!asset) {
+                reject(@"RN Uploader", @"Asset could not be fetched.  Are you missing permissions?", nil);
+                return;
+            }
+            PHAssetResource *assetResource = [[PHAssetResource assetResourcesForAsset:asset] firstObject];
+            NSString *pathToWrite = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
+            NSURL *pathUrl = [NSURL fileURLWithPath:pathToWrite];
+            fileURI = pathUrl.absoluteString;
+            
+            PHAssetResourceRequestOptions *options = [PHAssetResourceRequestOptions new];
+            options.networkAccessAllowed = YES;
 
-        dispatch_group_t group = dispatch_group_create();
-        dispatch_group_enter(group);
+            dispatch_group_t group = dispatch_group_create();
+            dispatch_group_enter(group);
+
+            __block NSError *error;
+            [[PHAssetResourceManager defaultManager] writeDataForAssetResource:assetResource toFile:pathUrl options:options completionHandler:^(NSError * _Nullable e) {
+                error = e;
+                dispatch_group_leave(group);
+            }];
+            dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+            if (error) {
+                reject(@"RN Uploader", @"Asset could not be copied.", nil);
+                return;
+            }
+        }
         
+        NSURLSessionDataTask *uploadTask;
+
         if ([uploadType isEqualToString:@"multipart"]) {
             NSString *uuidStr = [[NSUUID UUID] UUIDString];
             [request setValue:[NSString stringWithFormat:@"multipart/form-data; boundary=%@", uuidStr] forHTTPHeaderField:@"Content-Type"];
@@ -152,50 +180,10 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
 
             // I am sorry about warning, but Upload tasks from NSData are not supported in background sessions.
             uploadTask = [[self urlSession] uploadTaskWithRequest:request fromData: nil];
-            dispatch_group_leave(group);
         } else {
-//            //https://stackoverflow.com/questions/33278540/phasset-afnetworking-upload-multiple-videos
-            if ([fileURI hasPrefix:@"assets-library"]) {
-                NSURL *url = [NSURL URLWithString:fileURI];
-                PHAsset *asset = [PHAsset fetchAssetsWithALAssetURLs:@[url] options:nil].lastObject;
-                if (!asset) {
-                    reject(@"RN Uploader", @"Asset could not be fetched.  Are you missing permissions?", nil);
-                    return;
-                }
-                PHAssetResource *assetResource = [[PHAssetResource assetResourcesForAsset:asset] firstObject];
-//                NSString *pathToWrite = [NSTemporaryDirectory() stringByAppendingString:assetResource.originalFilename];
-                NSString *pathToWrite = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
-                NSURL *localpath = [NSURL fileURLWithPath:pathToWrite];
-
-                NSFileManager *fileManager = [NSFileManager defaultManager];
-//
-//                // Delete file if it already exists
-                if ([fileManager fileExistsAtPath:pathToWrite]) {
-                    [fileManager removeItemAtURL:localpath error:nil];
-                }
-                PHAssetResourceRequestOptions *options = [PHAssetResourceRequestOptions new];
-                options.networkAccessAllowed = YES;
-                // to get this working, consider something like https://stackoverflow.com/questions/4326350/how-do-i-wait-for-an-asynchronously-dispatched-block-to-finish
-                //http://www.g8production.com/post/76942348764/wait-for-blocks-execution-using-a-dispatch
-                [[PHAssetResourceManager defaultManager] writeDataForAssetResource:assetResource toFile:localpath options:options completionHandler:^(NSError * _Nullable error) {
-                    if (error) {
-                        reject(@"RN Uploader", @"Asset could not be copied.", nil);
-                        return;
-                    }
-                    uploadTask = [[self urlSession] uploadTaskWithRequest:request fromFile:localpath];
-                    dispatch_group_leave(group);
-                }];
-            } else {
-                uploadTask = [[self urlSession] uploadTaskWithRequest:request fromFile:[NSURL URLWithString: fileURI]];
-                dispatch_group_leave(group);
-            }
+            uploadTask = [[self urlSession] uploadTaskWithRequest:request fromFile:[NSURL URLWithString: fileURI]];
         }
-
-        dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
-//        dispatch_group_notify(serviceGroup,dispatch_get_main_queue(),^{
-//            // Won't get here until everything has finished
-//        });
-        
+    
         uploadTask.taskDescription = customUploadId ? customUploadId : [NSString stringWithFormat:@"%i", thisUploadId];
 
         [uploadTask resume];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-background-upload",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Cross platform http post file uploader with android and iOS background support",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If you upload a file directly from the photo library, you previously had to copy the asset into a temporary file, which some picker libraries apparently don't support.  Now the upload library supports that natively.

I did it by just copying the asset to a file.  iOS had no support for directly uploading them.  The best approach I found, and I researched a bunch, was from https://stackoverflow.com/questions/33278540/phasset-afnetworking-upload-multiple-videos

I took advantage of ObjC dispatch groups to make the actual implementation pretty straightforward.