### PR TITLE
Upgrade Android Uploader Service

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,9 +9,9 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
-def DEFAULT_COMPILE_SDK_VERSION = 25
-def DEFAULT_BUILD_TOOLS_VERSION = "25.0.2"
-def DEFAULT_TARGET_SDK_VERSION = 25
+def DEFAULT_COMPILE_SDK_VERSION = 27
+def DEFAULT_BUILD_TOOLS_VERSION = "27.0.3"
+def DEFAULT_TARGET_SDK_VERSION = 27
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
@@ -25,7 +25,7 @@ android {
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }
-    }    
+    }
     lintOptions {
         abortOnError false
     }
@@ -35,14 +35,6 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    /**
-     * Using okhttp is better because it fixes a possible outofmemory exception.
-     * However the okhttp library can have a funky version resolution and cause compilation errors with RN
-     * There is a PR to fix that
-     * https://github.com/facebook/react-native/pull/11835
-     * Until that is merged and RN is upgraded, you need to add this line to your android/app/build.gradle, inside 'android' block:
-     * configurations.all { resolutionStrategy.force 'com.squareup.okhttp3:okhttp:3.4.1' }
-    */
     compile 'com.facebook.react:react-native:+'
-    compile 'net.gotev:uploadservice-okhttp:3.2.3'
+    compile 'net.gotev:uploadservice-okhttp:3.4.2'
 }

--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -150,9 +150,13 @@ public class UploaderModule extends ReactContextBaseJavaModule {
         }
 
         @Override
-        public void onError(Context context, UploadInfo uploadInfo, Exception exception) {
+        public void onError(Context context, UploadInfo uploadInfo, ServerResponse serverResponse, Exception exception) {
           WritableMap params = Arguments.createMap();
           params.putString("id", customUploadId != null ? customUploadId : uploadInfo.getUploadId());
+          if (serverResponse != null) {
+            params.putInt("responseCode", serverResponse.getHttpCode());
+            params.putString("responseBody", serverResponse.getBodyAsString());
+          }
           params.putString("error", exception.getMessage());
           sendEvent("error", params);
         }


### PR DESCRIPTION
Bumped version of the Android Upload Service to the latest, which was recommended for its security updates - https://github.com/gotev/android-upload-service/releases/tag/3.4

Also bumped default compile sdk version for Android, since the latest upload service requires >= 26.

Needs tests in example app before merging.