### PR TITLE
Android notification features and Crash fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,19 +305,6 @@ Ensure `compileSdkVersion` and `targetSdkVersion` are 25.
 
 Done!
 
-## Known issues
-
-Android APK 27 and above require notifications to provide their own `NotificationChannel`. `react-native-background-upload` does not yet meet this requirement and thus [will cause crashes in Android 8.1 and above](https://github.com/Vydia/react-native-background-upload/issues/59#issuecomment-362476703). This issue can be avoided by electing not to use native notifications.
-
-```js
-const options = {
-  // ...
-  notification: {
-    enabled: false,
-  },
-};
-```
-
 
 ## Gratitude
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,23 @@ Returns a promise with the string ID of the upload.  Will reject if there is a c
 |`headers`|object|Optional||HTTP headers|`{ 'Accept': 'application/json' }`|
 |`field`|string|Required if `type: 'multipart'`||The form field name for the file.  Only used when `type: 'multipart`|`uploaded-file`|
 |`parameters`|object|Optional||Additional form fields to include in the HTTP request. Only used when `type: 'multipart`||
-|`notification`|object with single `enabled` field|Optional||Android only.  |`{ enabled: false }`|
+|`notification`|Notification object (see below)|Optional||Android only.  |`{ enabled: true, onProgressTitle: "Uploading...", autoClear: true }`|
+
+### Notification Object
+|Name|Type|Required|Description|Example|
+|---|---|---|---|---|
+|`enabled`|boolean|Optional|Enable or diasable notifications|`{ enabled: true }`|
+|`autoClear`|boolean|Optional|Autoclear notification on complete|`{ autoclear: true }`|
+|`notificationChannel`|string|Optional|Sets android notificaion channel|`{ notificationChannel: "My-Upload-Service" }`|
+|`onProgressTitle`|string|Optional|Sets notification progress title|`{ onProgressTitle: "Uploading" }`|
+|`onProgressMessage`|string|Optional|Sets notification progress message|`{ onProgressMessage: "Uploading new video" }`|
+|`onCompleteTitle`|string|Optional|Sets notification complete title|`{ onCompleteTitle: "Upload finished" }`|
+|`onCompleteMessage`|string|Optional|Sets notification complete message|`{ onCompleteMessage: "Your video has been uploaded" }`|
+|`onErrorTitle`|string|Optional|Sets notification error title|`{ onErrorTitle: "Upload error" }`|
+|`onErrorMessage`|string|Optional|Sets notification error message|`{ onErrorMessage: "An error occured while uploading a video" }`|
+|`onCancelledTitle`|string|Optional|Sets notification cancelled title|`{ onCancelledTitle: "Upload cancelled" }`|
+|`onCancelledMessage`|string|Optional|Sets notification cancelled message|`{ onCancelledMessage: "Video upload was cancelled" }`|
+
 
 ### getFileInfo(path)
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,9 +9,9 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
-def DEFAULT_COMPILE_SDK_VERSION = 25
-def DEFAULT_BUILD_TOOLS_VERSION = "25.0.2"
-def DEFAULT_TARGET_SDK_VERSION = 25
+def DEFAULT_COMPILE_SDK_VERSION = 27
+def DEFAULT_BUILD_TOOLS_VERSION = "27.0.3"
+def DEFAULT_TARGET_SDK_VERSION = 27
 
 android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
@@ -25,7 +25,7 @@ android {
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }
-    }    
+    }
     lintOptions {
         abortOnError false
     }
@@ -35,14 +35,6 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    /**
-     * Using okhttp is better because it fixes a possible outofmemory exception.
-     * However the okhttp library can have a funky version resolution and cause compilation errors with RN
-     * There is a PR to fix that
-     * https://github.com/facebook/react-native/pull/11835
-     * Until that is merged and RN is upgraded, you need to add this line to your android/app/build.gradle, inside 'android' block:
-     * configurations.all { resolutionStrategy.force 'com.squareup.okhttp3:okhttp:3.4.1' }
-    */
     compile 'com.facebook.react:react-native:+'
-    compile 'net.gotev:uploadservice-okhttp:3.2.3'
+    compile 'net.gotev:uploadservice-okhttp:3.4.2'
 }

--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -150,9 +150,13 @@ public class UploaderModule extends ReactContextBaseJavaModule {
         }
 
         @Override
-        public void onError(Context context, UploadInfo uploadInfo, Exception exception) {
+        public void onError(Context context, UploadInfo uploadInfo, ServerResponse serverResponse, Exception exception) {
           WritableMap params = Arguments.createMap();
           params.putString("id", customUploadId != null ? customUploadId : uploadInfo.getUploadId());
+          if (serverResponse != null) {
+            params.putInt("responseCode", serverResponse.getHttpCode());
+            params.putString("responseBody", serverResponse.getBodyAsString());
+          }
           params.putString("error", exception.getMessage());
           sendEvent("error", params);
         }

--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -159,9 +159,9 @@ public class UploaderModule extends ReactContextBaseJavaModule {
           }
 
           // Make sure we do not try to call getMessage() on a null object
-          if(exception != null){
+          if (exception != null){
             params.putString("error", exception.getMessage());
-          }else{
+          } else {
             params.putString("error", "Unknown exception");
           }
 
@@ -214,11 +214,11 @@ public class UploaderModule extends ReactContextBaseJavaModule {
 
         UploadNotificationConfig notificationConfig = new UploadNotificationConfig();
 
-        if(notification.hasKey("notificationChannel")){
+        if (notification.hasKey("notificationChannel")){
           notificationConfig.setNotificationChannelId(notification.getString("notificationChannel"));
         }
 
-        if(notification.hasKey("autoClear") && notification.getBoolean("autoClear")){
+        if (notification.hasKey("autoClear") && notification.getBoolean("autoClear")){
           notificationConfig.getCompleted().autoClear = true;
         }
 

--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -211,6 +211,43 @@ public class UploaderModule extends ReactContextBaseJavaModule {
           notificationConfig.setNotificationChannelId(notification.getString("notificationChannel"));
         }
 
+        if(notification.getBoolean("autoClear")){
+          notificationConfig.getCompleted().autoClear = true;
+        }
+
+        if (notification.hasKey("onCompleteTitle")) {
+          notificationConfig.getCompleted().title = notification.getString("onCompleteTitle");
+        }
+
+        if (notification.hasKey("onCompleteMessage")) {
+          notificationConfig.getCompleted().message = notification.getString("onCompleteMessage");
+        }
+
+        if (notification.hasKey("onErrorTitle")) {
+          notificationConfig.getError().title = notification.getString("onErrorTitle");
+        }
+
+        if (notification.hasKey("onErrorMessage")) {
+          notificationConfig.getError().message = notification.getString("onErrorMessage");
+        }
+
+        if (notification.hasKey("onProgressTitle")) {
+          notificationConfig.getProgress().title = notification.getString("onProgressTitle");
+        }
+
+        if (notification.hasKey("onProgressMessage")) {
+          notificationConfig.getProgress().message = notification.getString("onProgressMessage");
+        }
+
+        if (notification.hasKey("onCancelledTitle")) {
+          notificationConfig.getCancelled().title = notification.getString("onCancelledTitle");
+        }
+
+        if (notification.hasKey("onCancelledMessage")) {
+          notificationConfig.getCancelled().message = notification.getString("onCancelledMessage");
+        }
+        
+
         request.setNotificationConfig(notificationConfig);
 
       }

--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -204,7 +204,17 @@ public class UploaderModule extends ReactContextBaseJavaModule {
         .setDelegate(statusDelegate);
 
       if (notification.getBoolean("enabled")) {
-        request.setNotificationConfig(new UploadNotificationConfig());
+
+        UploadNotificationConfig notificationConfig = new UploadNotificationConfig();
+
+        if(notification.getString("channelId")){
+          notificationConfig.setNotificationChannelId(notification.getString("channelId"));
+        }else{
+          notificationConfig.setNotificationChannelId("Background-Upload-Service");
+        }
+
+        request.setNotificationConfig(notificationConfig);
+
       }
 
       if (options.hasKey("parameters")) {

--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -207,8 +207,8 @@ public class UploaderModule extends ReactContextBaseJavaModule {
 
         UploadNotificationConfig notificationConfig = new UploadNotificationConfig();
 
-        if(notification.getString("channelId")){
-          notificationConfig.setNotificationChannelId(notification.getString("channelId"));
+        if(notification.getString("notificationChannel")){
+          notificationConfig.setNotificationChannelId(notification.getString("notificationChannel"));
         }else{
           notificationConfig.setNotificationChannelId("Background-Upload-Service");
         }

--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -159,7 +159,7 @@ public class UploaderModule extends ReactContextBaseJavaModule {
           }
 
           // Make sure we do not try to call getMessage() on a null object
-          if(exception){
+          if(exception != null){
             params.putString("error", exception.getMessage());
           }else{
             params.putString("error", "Unknown exception");
@@ -218,7 +218,7 @@ public class UploaderModule extends ReactContextBaseJavaModule {
           notificationConfig.setNotificationChannelId(notification.getString("notificationChannel"));
         }
 
-        if(notification.getBoolean("autoClear")){
+        if(notification.hasKey("autoClear") && notification.getBoolean("autoClear")){
           notificationConfig.getCompleted().autoClear = true;
         }
 

--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -157,7 +157,14 @@ public class UploaderModule extends ReactContextBaseJavaModule {
             params.putInt("responseCode", serverResponse.getHttpCode());
             params.putString("responseBody", serverResponse.getBodyAsString());
           }
-          params.putString("error", exception.getMessage());
+
+          // Make sure we do not try to call getMessage() on a null object
+          if(exception){
+            params.putString("error", exception.getMessage());
+          }else{
+            params.putString("error", "Unknown exception");
+          }
+
           sendEvent("error", params);
         }
 
@@ -246,7 +253,6 @@ public class UploaderModule extends ReactContextBaseJavaModule {
         if (notification.hasKey("onCancelledMessage")) {
           notificationConfig.getCancelled().message = notification.getString("onCancelledMessage");
         }
-        
 
         request.setNotificationConfig(notificationConfig);
 

--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -207,10 +207,8 @@ public class UploaderModule extends ReactContextBaseJavaModule {
 
         UploadNotificationConfig notificationConfig = new UploadNotificationConfig();
 
-        if(notification.getString("notificationChannel")){
+        if(notification.hasKey("notificationChannel")){
           notificationConfig.setNotificationChannelId(notification.getString("notificationChannel"));
-        }else{
-          notificationConfig.setNotificationChannelId("Background-Upload-Service");
         }
 
         request.setNotificationConfig(notificationConfig);


### PR DESCRIPTION
This PR solves the android notification bug and introduces some new features for setting up notifications on android.

New features.
 - autoClear notification when upload is complete and successful
 - set notification titles and messages. perfect when using I18n.js 😁
 - set notification channel

Bug fixes
 - Fixed a crash when android-upload-service returned null instead of Exception object. (~~possible bug in android-upload-service~~, edit: android-upload-service returns null according to spec )
 - Notifications on android > 8.1

Tested on android 9, 8.1, 7.1 