### PR TITLE
Adds ability to set android ring tone on success/error

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Returns a promise with the string ID of the upload.  Will reject if there is a c
 |`parameters`|object|Optional||Additional form fields to include in the HTTP request. Only used when `type: 'multipart`||
 |`notification`|Notification object (see below)|Optional||Android only.  |`{ enabled: true, onProgressTitle: "Uploading...", autoClear: true }`|
 
-### Notification Object
+### Notification Object (Android Only)
 |Name|Type|Required|Description|Example|
 |---|---|---|---|---|
 |`enabled`|boolean|Optional|Enable or diasable notifications|`{ enabled: true }`|

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Returns a promise with the string ID of the upload.  Will reject if there is a c
 |`enabled`|boolean|Optional|Enable or diasable notifications|`{ enabled: true }`|
 |`autoClear`|boolean|Optional|Autoclear notification on complete|`{ autoclear: true }`|
 |`notificationChannel`|string|Optional|Sets android notificaion channel|`{ notificationChannel: "My-Upload-Service" }`|
+|`enableRingTone`|boolean|Optional|Sets whether or not to enable the notification sound when the upload gets completed with success or error|`{ enableRingTone: true }`|
 |`onProgressTitle`|string|Optional|Sets notification progress title|`{ onProgressTitle: "Uploading" }`|
 |`onProgressMessage`|string|Optional|Sets notification progress message|`{ onProgressMessage: "Uploading new video" }`|
 |`onCompleteTitle`|string|Optional|Sets notification complete title|`{ onCompleteTitle: "Upload finished" }`|

--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -222,6 +222,10 @@ public class UploaderModule extends ReactContextBaseJavaModule {
           notificationConfig.getCompleted().autoClear = true;
         }
 
+        if (notification.hasKey("enableRingTone") && notification.getBoolean("enableRingTone")){
+          notificationConfig.setRingToneEnabled(true);
+        }
+
         if (notification.hasKey("onCompleteTitle")) {
           notificationConfig.getCompleted().title = notification.getString("onCompleteTitle");
         }


### PR DESCRIPTION
This PR enables us to set the ``setRingToneEnabled(Boolean enabled)`` on the ``UploadNotificationConfig`` on Android.

I've added the property ``enableRingTone`` to the notification object to allow users to activate this feature.