### PR TITLE
Podspec for usage with cocoapods

### DIFF
--- a/VydiaRNFileUploader.podspec
+++ b/VydiaRNFileUploader.podspec
@@ -1,0 +1,18 @@
+require 'json'
+version = JSON.parse(File.read('package.json'))["version"]
+
+Pod::Spec.new do |s|
+
+  s.name           = "VydiaRNFileUploader"
+  s.version        = version
+  s.summary        = "iOS wrapper for React Native background file upload"
+  s.homepage       = "https://github.com/Vydia/react-native-background-upload"
+  s.license        = "MIT"
+  s.author         = { "Vydia" => "example@email.com" }
+  s.platform       = :ios, "7.0"
+  s.source         = { :git => "https://github.com/Vydia/react-native-background-upload.git", :tag => "v#{s.version}" }
+  s.source_files   = 'VydiaRNFileUploader/**/*.{h,m}'
+  s.preserve_paths = "**/*.js"
+  s.dependency 'React'
+
+end


### PR DESCRIPTION
A podspec is needed to use this project with a pod setup for React Native iOS. Example usage in the project's Podfile:
```
pod 'VydiaRNFileUploader', :path => '../node_modules/react-native-background-upload'
```