### PR TITLE
Adds return info for addListener

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ Adds an event listener, possibly confined to a single upload.
 
 `listener` Function to call when the event occurs.
 
+Returns an [EventSubscription](https://github.com/facebook/react-native/blob/master/Libraries/vendor/emitter/EmitterSubscription.js). To remove the listener, call `remove()` on the `EventSubscription`.
+
 ## Events
 
 ### progress


### PR DESCRIPTION
This change makes it more obvious how to remove a listener that has been added. It took me a little digging to realize that I needed to call `subscription.remove()` instead of there being a `removeListener` method.