### PR TITLE
fix cancelUpload not working

### DIFF
--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -226,7 +226,8 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
 RCT_EXPORT_METHOD(cancelUpload: (NSString *)cancelUploadId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     [_urlSession getTasksWithCompletionHandler:^(NSArray *dataTasks, NSArray *uploadTasks, NSArray *downloadTasks) {
         for (NSURLSessionTask *uploadTask in uploadTasks) {
-            if (uploadTask.taskDescription == cancelUploadId) {
+            if ([uploadTask.taskDescription isEqualToString:cancelUploadId]){
+                // == checks if references are equal, while isEqualToString checks the string value
                 [uploadTask cancel];
             }
         }


### PR DESCRIPTION
Cancelling an upload is never working, due to the obj-C `if` condition which was comparing references, instead of strings.