### PR TITLE
Fix the repo url format

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Vydia/react-native-background-upload.git"
+    "url": "https://github.com/Vydia/react-native-background-upload.git"
   },
   "keywords": [
     "NSURLSession",


### PR DESCRIPTION
This fix is needed to allow the library to be installed using the Cocoapods podspec file. Without this change, you get this error while attempting to run `pod install`:

```
Installing react-native-background-upload (5.0.0)

[!] Error installing react-native-background-upload
[!] /usr/local/bin/git clone git+https://github.com/Vydia/react-native-background-upload.git /var/folders/rh/zjc3x5b91k3gsw1bsl91nw200000gn/T/d20190110-76297-1gnxeok --template= --single-branch --depth 1

Cloning into '/var/folders/rh/zjc3x5b91k3gsw1bsl91nw200000gn/T/d20190110-76297-1gnxeok'...
fatal: unable to find remote helper for 'git+https'
```