### PR TITLE
upload more than 2 videos at the same time

### DIFF
--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -197,8 +197,8 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
             NSData *httpBody = [self createBodyWithBoundary:uuidStr path:fileURI parameters: parameters fieldName:fieldName];
             [request setHTTPBody: httpBody];
 
-            // I am sorry about warning, but Upload tasks from NSData are not supported in background sessions.
-            uploadTask = [[self urlSession] uploadTaskWithRequest:request fromData: nil];
+            //using uploadTaskWithStreamedRequest instead of uploadTaskWithRequest to ensure more than 2 video uploads at the same time
+            uploadTask = [[self urlSession] uploadTaskWithStreamedRequest:request];
         } else {
             if (parameters.count > 0) {
                 reject(@"RN Uploader", @"Parameters supported only in multipart type", nil);


### PR DESCRIPTION
This PR ensures that more than 2 videos can be uploaded concurrently. The previous behavior was that when we upload the 3rd video, "Lost connection to background services" error appears and all the videos get stuck (this is another issue, please have a look #134 ).

Check out the difference between uploadTask and uploadStreamedTask on Apple's documentation, [Upload Task](https://developer.apple.com/documentation/foundation/url_loading_system/uploading_data_to_a_website) vs. [Upload Streamed Task](https://developer.apple.com/documentation/foundation/url_loading_system/uploading_streams_of_data).

I based my fix on this [suggestion](https://github.com/wkh237/react-native-fetch-blob/issues/448#issuecomment-365359395) found in `react-native-fetch-blob` library's issues.