### PR TITLE
dismiss cancelled and error notifications if autoClear set to true

### DIFF
--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -220,6 +220,8 @@ public class UploaderModule extends ReactContextBaseJavaModule {
 
         if (notification.hasKey("autoClear") && notification.getBoolean("autoClear")){
           notificationConfig.getCompleted().autoClear = true;
+          notificationConfig.getCancelled().autoClear = true;
+          notificationConfig.getError().autoClear = true;
         }
 
         if (notification.hasKey("enableRingTone") && notification.getBoolean("enableRingTone")){


### PR DESCRIPTION
We make heavy use of this library, but were not able to upgrade to v5.0.0 because of the notifications on Android, which were overwhelming for users who might go online and offline multiple times before an upload succeeded.

However, it appears that the underlying Android uploader supports auto-clearing the canceled and error notifications, which is what we need to be able to use this library.

It seems to me that if applications want to auto clear notifications, they ought to be able to clear cancellations and errors as well - there are plenty of ways to present those notifications directly to a user if desired. Oreo requires the in-progress notification but does not require any others, so these notifications are essentially spam for many applications.

The fix was extremely simple, but if preferred we could change this to allow applications to specify autoClear config for each notification state individually.