### PR TITLE
Feature: support for iOS completion events while the app is in background

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Note: if you are installing on React Native < 0.47, use `react-native-background
 
 1. In the XCode's "Project navigator", right click on your project's Libraries folder ➜ `Add Files to <...>`
 2. Go to `node_modules` ➜ `react-native-background-upload` ➜ `ios` ➜ select `VydiaRNFileUploader.xcodeproj`
-3. Add `VydiaRNFileUploader.a` to `Build Phases -> Link Binary With Libraries`
+3. In the project `Build Settings`, search for `Header Search Paths` and add `$(SRCROOT)/../node_modules/react-native-background-upload/ios` to the list (non-recursive).
+4. Add `VydiaRNFileUploader.a` to `Build Phases -> Link Binary With Libraries`
 
 #### Android
 1. Add the following lines to `android/settings.gradle`:
@@ -69,7 +70,7 @@ Note: if you are installing on React Native < 0.47, use `react-native-background
 
 ## 3. Expo
 
-To use this library with [Expo](https://expo.io) one must first detach (eject) the project and follow [step 2](#2-link-native-code) instructions. Additionally on iOS there is a must to add a Header Search Path to other dependencies which are managed using Pods. To do so one has to add `$(SRCROOT)/../../../ios/Pods/Headers/Public` to Header Search Path in `VydiaRNFileUploader` module using XCode. 
+To use this library with [Expo](https://expo.io) one must first detach (eject) the project and follow [step 2](#2-link-native-code) instructions. Additionally on iOS there is a must to add a Header Search Path to other dependencies which are managed using Pods. To do so one has to add `$(SRCROOT)/../../../ios/Pods/Headers/Public` to Header Search Path in `VydiaRNFileUploader` module using XCode.
 
 # Usage
 
@@ -126,6 +127,66 @@ const options = {
 ```
 
 Note the `field` property is required for multipart uploads.
+
+## iOS Background Events
+
+By default, iOS does not wake up your app when uploads are done while your app is not in the foreground. To receive the upload events (`error`, `completed`...) while your app is in the background, add the following to your `AppDelegate.m`:
+
+```objective-c
+#import "VydiaRNFileUploader.h"
+
+- (void)application:(UIApplication *)application
+        handleEventsForBackgroundURLSession:(NSString *)identifier
+        completionHandler:(void (^)(void))completionHandler {
+  [VydiaRNFileUploader setBackgroundSessionCompletionHandler:completionHandler];
+}
+```
+
+This means you can do extra work in the background, like make network calls or uploads more files! You _must_ call `canSuspendIfBackground` when you are done processing the events to sleep again. You can safely call this method when you are not in the background.
+
+Here is a JS example:
+
+```javascript
+import RNBackgroundUpload from 'react-native-background-upload';
+
+async function uploadFile(url, fileURI) {
+  const uploadId = await RNBackgroundUpload.startUpload({ url, path: fileURI, method: 'POST' });
+  return new Promise((resolve, reject) => {
+    RNBackgroundUpload.addListener('error', uploadId, reject);
+    RNBackgroundUpload.addListener('cancelled', uploadId, () => reject(new Error('upload cancelled')));
+    RNBackgroundUpload.addListener('completed', uploadId, ({ responseCode, responseBody }) => {
+      if (200 <= responseCode && responseCode <= 299) {
+          resolve(uploadId);
+      } else {
+          reject(new Error(`Could not upload file (${responseCode}): ${responseBody}`));
+      }
+    });
+  });
+}
+
+async function uploadManyFilesThenPOST(files) {
+  try {
+    await Promise.all(files.map(fileURI => uploadFile('https://example.com/upload', fileURI)));
+    const response = await fetch('https://example.com/confirmUploads', { method: 'POST' });
+    if (!response.ok) throw new Error('Could not confirm uploads');
+  } catch (error) {
+    const response = await fetch('https://example.com/failedUploads', { method: 'POST' });
+    if (!response.ok) throw new Error('Could not report failed uploads');
+  }
+  RNBackgroundUpload.canSuspendIfBackground();
+}
+```
+
+The function `uploadManyFilesThenPOST` schedules all the file uploads at once. This is recommended because the OS can then make progress on all uploads even while your app sleeps. This may take some time as iOS decides to upload when it deems appropriate, e.g. when the device is charging and connected to WiFi. Inversely, when the device is low on battery or in energy saver mode, background uploads won't make progress.
+
+When all uploads are finished, your app _may_ be resumed in the background to receive the events. You should call `canSuspendIfBackground` as soon as possible when you are done with other actions to conserve your app "background credit". If you don't call `canSuspendIfBackground`, the library will call it for your after ~45 seconds. This makes sure that your app won't be killed by the OS right away but pretty much consumes all your background credit.
+
+When your app is brought to the foreground, uploads will continue regardless of background credit.
+
+Uploads initiated while the app is in the background are always [discretionary](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1411552-discretionary?language=objc), so iOS will be more aggressive to conserve energy. Uploads started in the foreground are not [discretionary](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1411552-discretionary?language=objc) so they start right away.
+
+If your app is dead (forced closed by the user via the app switcher or by the OS to reclaim memory) when uploads complete, iOS will launch it in the background. The given example does not handle this case, i.e. there will be no `POST` to `https://example.com/confirmUploads`. To support this, you can save the `uploadId`(s) to a file (e.g. via `AsyncStorage`), read it when your app starts and add the 3 listeners back.
+
 
 # API
 
@@ -208,6 +269,30 @@ Adds an event listener, possibly confined to a single upload.
 
 Returns an [EventSubscription](https://github.com/facebook/react-native/blob/master/Libraries/vendor/emitter/EmitterSubscription.js). To remove the listener, call `remove()` on the `EventSubscription`.
 
+### canSuspendIfBackground()
+
+If you are not using iOS background events, you can ignore this method.
+
+Notify the OS that your app can sleep again. Call this method when your app has done all its work or is waiting for background uploads to complete. Upon calling the method, you app is suspended if it's running in the background. Native code and JS will pause execution. Apple recommends you keep background execution time at less than 5 to 10 sec.
+
+Here are a few common situations and how to handle them:
+
+ - Uploads are finished (completed, error or cancelled) and your app does not need to do any more work. You should call `canSuspendIfBackground` after receiving the events.
+ 
+ - Uploads are finished (completed, error or cancelled) and your app needs to run some computation or make a network request. You should call `canSuspendIfBackground` after the computation or network call is done.
+ 
+ - Uploads are finished (completed, error or cancelled) and your app needs to upload some more. You call `startUpload` a number of times and add your listeners. You should call `canSuspendIfBackground` after the uploads start but not wait for them to finish. You also need to call `canSuspendIfBackground` after you have received the events, even if some uploads are cancelled or fail.
+ 
+```javascript
+async function uploadFilesWhileInBackground() {
+  const uploadIds = await Promise.all(files.map(fileUri => startUpload(...)));
+  canSuspendIfBackground();
+  await Promise.all(uploadIds.map(id => listenForUploadCompletion(id)));
+  canSuspendIfBackground();
+}
+```
+
+
 ## Events
 
 ### progress
@@ -287,9 +372,23 @@ Does it support iOS camera roll assets?
 
 > Yes, as of version 4.3.0.
 
+I'm not receiving events while the app is in background!
+
+> There are no background events on Android. For iOS, add the following in your `AppDelegate.m`:
+
+```objective-c
+#import "VydiaRNFileUploader.h"
+
+- (void)application:(UIApplication *)application
+        handleEventsForBackgroundURLSession:(NSString *)identifier
+        completionHandler:(void (^)(void))completionHandler {
+  [VydiaRNFileUploader setBackgroundSessionCompletionHandler:completionHandler];
+}
+```
+
 Does it support multiple file uploads?
 
-> Yes and No.  It supports multiple concurrent uploads, but only a single upload per request.  That should be fine for 90%+ of cases.
+> Yes and No.  It supports multiple concurrent uploads, but only a single file upload per request.
 
 Why should I use this file uploader instead of others that I've Googled like [react-native-uploader](https://github.com/aroth/react-native-uploader)?
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Returns an [EventSubscription](https://github.com/facebook/react-native/blob/mas
 
 ### canSuspendIfBackground()
 
-If you are not using iOS background events, you can ignore this method.
+If you are not using [iOS background events](#ios-background-events), you can ignore this method.
 
 Notify the OS that your app can sleep again. Call this method when your app has done all its work or is waiting for background uploads to complete. Upon calling the method, you app is suspended if it's running in the background. Native code and JS will pause execution. Apple recommends you keep background execution time at less than 5 to 10 sec.
 

--- a/README.md
+++ b/README.md
@@ -128,66 +128,6 @@ const options = {
 
 Note the `field` property is required for multipart uploads.
 
-## iOS Background Events
-
-By default, iOS does not wake up your app when uploads are done while your app is not in the foreground. To receive the upload events (`error`, `completed`...) while your app is in the background, add the following to your `AppDelegate.m`:
-
-```objective-c
-#import "VydiaRNFileUploader.h"
-
-- (void)application:(UIApplication *)application
-        handleEventsForBackgroundURLSession:(NSString *)identifier
-        completionHandler:(void (^)(void))completionHandler {
-  [VydiaRNFileUploader setBackgroundSessionCompletionHandler:completionHandler];
-}
-```
-
-This means you can do extra work in the background, like make network calls or uploads more files! You _must_ call `canSuspendIfBackground` when you are done processing the events to sleep again. You can safely call this method when you are not in the background.
-
-Here is a JS example:
-
-```javascript
-import RNBackgroundUpload from 'react-native-background-upload';
-
-async function uploadFile(url, fileURI) {
-  const uploadId = await RNBackgroundUpload.startUpload({ url, path: fileURI, method: 'POST' });
-  return new Promise((resolve, reject) => {
-    RNBackgroundUpload.addListener('error', uploadId, reject);
-    RNBackgroundUpload.addListener('cancelled', uploadId, () => reject(new Error('upload cancelled')));
-    RNBackgroundUpload.addListener('completed', uploadId, ({ responseCode, responseBody }) => {
-      if (200 <= responseCode && responseCode <= 299) {
-          resolve(uploadId);
-      } else {
-          reject(new Error(`Could not upload file (${responseCode}):\n${responseBody}`));
-      }
-    });
-  });
-}
-
-async function uploadManyFilesThenPOST(files) {
-  try {
-    await Promise.all(files.map(fileURI => uploadFile('https://example.com/upload', fileURI)));
-    const response = await fetch('https://example.com/confirmUploads', { method: 'POST' });
-    if (!response.ok) throw new Error('Could not confirm uploads');
-  } catch (error) {
-    const response = await fetch('https://example.com/failedUploads', { method: 'POST' });
-    if (!response.ok) throw new Error('Could not report failed uploads');
-  }
-  RNBackgroundUpload.canSuspendIfBackground();
-}
-```
-
-The function `uploadManyFilesThenPOST` schedules all the file uploads at once. This is recommended because the OS can then make progress on all uploads even while your app sleeps. This may take some time as iOS decides to upload when it deems appropriate, e.g. when the device is charging and connected to WiFi. Inversely, when the device is low on battery or in energy saver mode, background uploads won't make progress.
-
-When all uploads are finished, your app _may_ be resumed in the background to receive the events. You should call `canSuspendIfBackground` as soon as possible when you are done with other actions to conserve your app "background credit". If you don't call `canSuspendIfBackground`, the library will call it for your after ~45 seconds. This makes sure that your app won't be killed by the OS right away but pretty much consumes all your background credit.
-
-When your app is brought to the foreground, uploads will continue regardless of background credit.
-
-Uploads initiated while the app is in the background are always [discretionary](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1411552-discretionary?language=objc), so iOS will be more aggressive to conserve energy. Uploads started in the foreground are not [discretionary](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1411552-discretionary?language=objc) so they start right away.
-
-If your app is dead (forced closed by the user via the app switcher or by the OS to reclaim memory) when uploads complete, iOS will launch it in the background. The given example does not handle this case, i.e. there will be no `POST` to `https://example.com/confirmUploads`. To support this, you can save the `uploadId`(s) to a file (e.g. via `AsyncStorage`), read it when your app starts and add the 3 listeners back.
-
-
 # API
 
 ## Top Level Functions
@@ -284,11 +224,13 @@ Here are a few common situations and how to handle them:
  - Uploads are finished (completed, error or cancelled) and your app needs to upload some more. You call `startUpload` a number of times and add your listeners. You should call `canSuspendIfBackground` after the uploads start but not wait for them to finish. You also need to call `canSuspendIfBackground` after you have received the events, even if some uploads are cancelled or fail:
  
 ```javascript
+import { addListener, startUpload, canSuspendIfBackground } from 'react-native-background-upload';
+
 function listenForUploadCompletion(uploadId) {
   return new Promise((resolve, reject) => {
-    RNBackgroundUpload.addListener('error', uploadId, reject);
-    RNBackgroundUpload.addListener('cancelled', uploadId, () => reject(new Error('upload cancelled')));
-    RNBackgroundUpload.addListener('completed', uploadId, ({ responseCode, responseBody }) => {
+    addListener('error', uploadId, reject);
+    addListener('cancelled', uploadId, () => reject(new Error('upload cancelled')));
+    addListener('completed', uploadId, ({ responseCode, responseBody }) => {
       if (200 <= responseCode && responseCode <= 299) {
           resolve(uploadId);
       } else {
@@ -351,6 +293,63 @@ Event Data
 |Name|Type|Required|Description|
 |---|---|---|---|
 |`id`|string|Required|The ID of the upload.|
+
+# iOS Background Events
+
+By default, iOS does not wake up your app when uploads are done while your app is not in the foreground. To receive the upload events (`error`, `completed`...) while your app is in the background, add the following to your `AppDelegate.m`:
+
+```objective-c
+#import "VydiaRNFileUploader.h"
+
+- (void)application:(UIApplication *)application
+        handleEventsForBackgroundURLSession:(NSString *)identifier
+        completionHandler:(void (^)(void))completionHandler {
+  [VydiaRNFileUploader setBackgroundSessionCompletionHandler:completionHandler];
+}
+```
+
+This means you can do extra work in the background, like make network calls or uploads more files! You _must_ call `canSuspendIfBackground` when you are done processing the events to sleep again. You can safely call this method when you are not in the background.
+
+Here is a JS example:
+
+```javascript
+import RNBackgroundUpload from 'react-native-background-upload';
+
+async function uploadFile(url, fileURI) {
+  const uploadId = await RNBackgroundUpload.startUpload({ url, path: fileURI, method: 'POST' });
+  return new Promise((resolve, reject) => {
+    RNBackgroundUpload.addListener('error', uploadId, reject);
+    RNBackgroundUpload.addListener('cancelled', uploadId, () => reject(new Error('upload cancelled')));
+    RNBackgroundUpload.addListener('completed', uploadId, ({ responseCode, responseBody }) => {
+      if (200 <= responseCode && responseCode <= 299) {
+          resolve(uploadId);
+      } else {
+          reject(new Error(`Could not upload file (${responseCode}):\n${responseBody}`));
+      }
+    });
+  });
+}
+
+async function uploadManyFilesThenPOST(files) {
+  try {
+    await Promise.all(files.map(fileURI => uploadFile('https://example.com/upload', fileURI)));
+    const response = await fetch('https://example.com/confirmUploads', { method: 'POST' });
+    if (!response.ok) throw new Error('Could not confirm uploads');
+  } catch (error) {
+    const response = await fetch('https://example.com/failedUploads', { method: 'POST' });
+    if (!response.ok) throw new Error('Could not report failed uploads');
+  }
+  RNBackgroundUpload.canSuspendIfBackground();
+}
+```
+
+The function `uploadManyFilesThenPOST` schedules all the file uploads at once. This is recommended because the OS can then make progress on all uploads even while your app sleeps. This may take some time as iOS decides to upload when it deems appropriate, e.g. when the device is charging and connected to WiFi. Inversely, when the device is low on battery or in energy saver mode, background uploads won't make progress.
+
+When all uploads are finished, your app _may_ be resumed in the background to receive the events. You should call `canSuspendIfBackground` as soon as possible when you are done with other actions to conserve your app "background credit". If you don't call `canSuspendIfBackground`, the library will call it for your after ~45 seconds. This makes sure that your app won't be killed by the OS right away but pretty much consumes all your background credit.
+
+Uploads tasks started when the app is in the background are [discretionary](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1411552-discretionary?language=objc); iOS will typically upload the files later when the device is charging. Upload tasks started in the foreground are not [discretionary](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1411552-discretionary?language=objc) and start right away. When your app is brought to the foreground, uploads that have been postponed by the OS will continue regardless of background credit.
+
+If your app is dead when uploads complete (force-closed by the user via the app switcher or by the OS to reclaim memory), iOS will launch it in the background. The above example does not handle this case, i.e. there will be no `POST` to `https://example.com/confirmUploads`. To support this you should save the `uploadId`(s) to a file (e.g. via `AsyncStorage`), read it when your app starts, and add the 3 listeners back.
 
 # Customizing Android Build Properties
 You may want to customize the `compileSdk, buildToolsVersion, and targetSdkVersion` versions used by this package.  For that, add this to `android/build.gradle`:

--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -50,7 +50,13 @@ public class UploaderModule extends ReactContextBaseJavaModule {
   Sends an event to the JS module.
    */
   private void sendEvent(String eventName, @Nullable WritableMap params) {
-    this.getReactApplicationContext().getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit("RNFileUploader-" + eventName, params);
+    this.getReactApplicationContext()
+        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+        .emit("RNFileUploader-" + eventName, params);
+  }
+
+  private String convertURI(String pathOrURI) {
+    return pathOrURI.startsWith("file://") ? pathOrURI.substring(7) : pathOrURI;
   }
 
   /*
@@ -61,22 +67,18 @@ public class UploaderModule extends ReactContextBaseJavaModule {
   public void getFileInfo(String path, final Promise promise) {
     try {
       WritableMap params = Arguments.createMap();
-      File fileInfo = new File(path);
+      File fileInfo = new File(convertURI(path));
       params.putString("name", fileInfo.getName());
-      if (!fileInfo.exists() || !fileInfo.isFile())
-      {
+      if (!fileInfo.exists() || !fileInfo.isFile()) {
         params.putBoolean("exists", false);
-      }
-      else
-      {
+      } else {
         params.putBoolean("exists", true);
-        params.putString("size",Long.toString(fileInfo.length())); //use string form of long because there is no putLong and converting to int results in a max size of 17.2 gb, which could happen.  Javascript will need to convert it to a number
+        params.putDouble("size", fileInfo.length());
         String extension = MimeTypeMap.getFileExtensionFromUrl(path);
-        params.putString("extension",extension);
+        params.putString("extension", extension);
         String mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension.toLowerCase());
         params.putString("mimeType", mimeType);
       }
-
       promise.resolve(params);
     } catch (Exception exc) {
       Log.e(TAG, exc.getMessage(), exc);
@@ -134,7 +136,7 @@ public class UploaderModule extends ReactContextBaseJavaModule {
     }
 
     String url = options.getString("url");
-    String filePath = options.getString("path");
+    String filePath = convertURI(options.getString("path"));
     String method = options.hasKey("method") && options.getType("method") == ReadableType.String ? options.getString("method") : "POST";
 
     final String customUploadId = options.hasKey("customUploadId") && options.getType("method") == ReadableType.String ? options.getString("customUploadId") : null;

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ if (NativeModules.VydiaRNFileUploader) {
 /*
 Gets file information for the path specified.
 Example valid path is:
-  Android: '/storage/extSdCard/DCIM/Camera/20161116_074726.mp4'
+  Android: '/storage/extSdCard/DCIM/Camera/20161116_074726.mp4' or 'file:///storage/extSdCard/DCIM/Camera/20161116_074726.mp4'
   iOS: 'file:///var/mobile/Containers/Data/Application/3C8A0EFB-A316-45C0-A30A-761BF8CCF2F8/tmp/trim.A5F76017-14E9-4890-907E-36A045AF9436.MOV;
 
 Returns an object:
@@ -63,7 +63,7 @@ Starts uploading a file to an HTTP endpoint.
 Options object:
 {
   url: string.  url to post to.
-  path: string.  path to the file on the device
+  path: string.  path to the file on the device ("file://" prefixed path)
   headers: hash of name/value header pairs
   method: HTTP method to use.  Default is "POST"
   notification: hash for customizing tray notifiaction

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 /**
  * Handles HTTP background file uploads from an iOS or Android device.
  */
-import { NativeModules, DeviceEventEmitter } from 'react-native'
+import { NativeModules, DeviceEventEmitter, Platform } from 'react-native'
 
 export type UploadEvent = 'progress' | 'error' | 'completed' | 'cancelled'
 
@@ -25,7 +25,7 @@ export type StartUploadArgs = {
   notification?: NotificationArgs
 }
 
-const NativeModule = NativeModules.VydiaRNFileUploader || NativeModules.RNFileUploader // iOS is VydiaRNFileUploader and Android is NativeModules 
+const NativeModule = NativeModules.VydiaRNFileUploader || NativeModules.RNFileUploader // iOS is VydiaRNFileUploader and Android is NativeModules
 const eventPrefix = 'RNFileUploader-'
 
 // for IOS, register event listeners or else they don't fire on DeviceEventEmitter
@@ -50,16 +50,16 @@ The promise should never be rejected.
 */
 export const getFileInfo = (path: string): Promise<Object> => {
   return NativeModule.getFileInfo(path)
-  .then(data => {
-    if (data.size) {  // size comes back as a string on android so we convert it here.  if it's already a number this won't hurt anything
-      data.size = +data.size
-    }
-    return data
-  })
+    .then(data => {
+      if (data.size) {  // size comes back as a string on android so we convert it here.  if it's already a number this won't hurt anything
+        data.size = +data.size
+      }
+      return data
+    })
 }
 
 /*
-Starts uploading a file to an HTTP endpoint.  
+Starts uploading a file to an HTTP endpoint.
 Options object:
 {
   url: string.  url to post to.
@@ -97,7 +97,7 @@ export const cancelUpload = (cancelUploadId: string): Promise<boolean> => {
 }
 
 /*
-Listens for the given event on the given upload ID (resolved from startUpload).  
+Listens for the given event on the given upload ID (resolved from startUpload).
 If you don't supply a value for uploadId, the event will fire for all uploads.
 Events (id is always the upload ID):
   progress - { id: string, progress: int (0-100) }
@@ -113,4 +113,10 @@ export const addListener = (eventType: UploadEvent, uploadId: string, listener: 
   })
 }
 
-export default { startUpload, cancelUpload, addListener, getFileInfo }
+export const canSuspendIfBackground = () => {
+  if (Platform.OS === 'ios') {
+    NativeModule.canSuspendIfBackground();
+  }
+};
+
+export default { startUpload, cancelUpload, addListener, getFileInfo, canSuspendIfBackground }

--- a/ios/VydiaRNFileUploader.h
+++ b/ios/VydiaRNFileUploader.h
@@ -1,0 +1,10 @@
+//  VydiaRNFileUploader.h
+
+#import <Foundation/Foundation.h>
+#import <MobileCoreServices/MobileCoreServices.h>
+#import <React/RCTEventEmitter.h>
+#import <React/RCTBridgeModule.h>
+
+@interface VydiaRNFileUploader : RCTEventEmitter <RCTBridgeModule, NSURLSessionTaskDelegate>
+    +(void)setBackgroundSessionCompletionHandler:(void (^)(void))handler;
+@end

--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -335,14 +335,14 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
 }
 
 - (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session {
-    NSLog(@"RNBU did finish events for background URL session");
     if (backgroundSessionCompletionHandler) {
         double delayInSeconds = 1.0;
         dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, delayInSeconds * NSEC_PER_SEC);
         dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
-            backgroundSessionCompletionHandler();
-            backgroundSessionCompletionHandler = nil;
-            NSLog(@"RNBU did invoque backgroundSessionCompletionHandler");
+            if (backgroundSessionCompletionHandler) {
+                backgroundSessionCompletionHandler();
+                backgroundSessionCompletionHandler = nil;
+            }
         });
     }
 }

--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -45,11 +45,19 @@ void (^backgroundSessionCompletionHandler)(void) = nil;
     ];
 }
 
+- (void)startObserving {
+    // JS side is ready to receive events; create the background url session if necessary
+    // iOS will then deliver the tasks completed while the app was dead (if any)
+    double delayInSeconds = 0.5;
+    dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, delayInSeconds * NSEC_PER_SEC);
+    dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
+        NSLog(@"RNBU startObserving: recreate urlSession if necessary");
+        [self urlSession];
+    });
+}
+
 + (void)setBackgroundSessionCompletionHandler:(void (^)(void))handler {
     backgroundSessionCompletionHandler = handler;
-    // Create the background url session if the app was open from the background
-    // iOS will then deliver the completed tasks in the NSURLSessionTaskDelegate
-    [staticInstance urlSession];
     NSLog(@"RNBU did setBackgroundSessionCompletionHandler");
 }
 

--- a/ios/VydiaRNFileUploader.xcodeproj/project.pbxproj
+++ b/ios/VydiaRNFileUploader.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 /* Begin PBXFileReference section */
 		014A3B5C1C6CF33500B6D375 /* libVydiaRNFileUploader.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libVydiaRNFileUploader.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCC748841E044F8700EA453E /* VydiaRNFileUploader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VydiaRNFileUploader.m; sourceTree = "<group>"; };
+		E7549807229D344D00BA2049 /* VydiaRNFileUploader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VydiaRNFileUploader.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -41,6 +42,7 @@
 		014A3B531C6CF33500B6D375 = {
 			isa = PBXGroup;
 			children = (
+				E7549807229D344D00BA2049 /* VydiaRNFileUploader.h */,
 				DCC748841E044F8700EA453E /* VydiaRNFileUploader.m */,
 				014A3B5D1C6CF33500B6D375 /* Products */,
 			);
@@ -93,6 +95,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 014A3B531C6CF33500B6D375;


### PR DESCRIPTION
### Problem

Currently, the uploads tasks initiated by the app while in foreground continue to completion even if the app is backgrounded. Unfortunately, the app does not wake up to receive the `URLSession:task:didCompleteWithError` event until it is brought to foreground by the user. This means the app does not receive any events (e.g. "completed") until then.

### What this PR does

This PR adds a `setBackgroundSessionCompletionHandler` setter in the library to let the AppDelegate set the background session completion handler when it receives the `application:handleEventsForBackgroundURLSession:completionHandler` event. The lib will then wait for a short time to let the JS side provide new tasks (if any) and call the handler to sleep again.

Here is a sample implementation for the AppDelegate:

```
#import "VydiaRNFileUploader.h"
// ...
- (void)application:(UIApplication *)application
        handleEventsForBackgroundURLSession:(NSString *)identifier
        completionHandler:(void (^)(void))completionHandler {
  [VydiaRNFileUploader setBackgroundSessionCompletionHandler:completionHandler];
}
```

There should be no regression if the AppDelegate does not implement this. Most apps don't create more tasks after completion so they won't need this addition.

Feel free to amend this PR or discuss the changes.

### Install steps

`$(SRCROOT)/../node_modules/react-native-background-upload/ios` must be added to the header search paths to enable the AppDelegate to find "VydiaRNFileUploader.h". Do you know how to automate this with `react-native link` ?

### Notes

I took the liberty to lint some statements. I can revert this if you don't like it.