### PR TITLE
add-targetsdk-28-upgrade

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,5 @@
-## Issues
+## Issues 
 
-Along with a bug report, provide a functional example repository which
-reproduces the bug you're experiencing. We've made this very easy by providing
-a full-stack (React Native + Express.js) example app, which you can fork and
-alter to reproduce your bug:
+According to Google. From November 1, 2019, all updates must target at least Android 9.0 / API level 28. Furthermore, all new uploads have to comply with this requirement. If you're build a new app, this is the basic requirement. When using RN 0.60+ you have to upgrade the minsdk or else the app will either not build or the background upload will crash while trying to update. Issue #169 details this issue further.
 
-[ReactNativeBackgroundUploadExample](https://github.com/Vydia/ReactNativeBackgroundUploadExample)
+[Repro](https://github.com/teeolendo/ReactNativeBackgroundUploadExample)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ android {
     buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 18
         targetSdkVersion project.hasProperty('targetSdkVersion') ? project.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"
@@ -36,5 +36,5 @@ repositories {
 }
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'net.gotev:uploadservice-okhttp:3.4.2'
+    compile 'net.gotev:uploadservice-okhttp:3.5.0'
 }


### PR DESCRIPTION
According to Google. From November 1, 2019, all updates must target at least Android 9.0 / API level 28. Furthermore, all new uploads have to comply with this requirement. If you're build a new app, this is the basic requirement. When using RN 0.60+ you have to upgrade the minsdk or else the app will either not build or the background upload will crash while trying to update. Issue #169 details this issue further.

Repro: https://github.com/teeolendo/ReactNativeBackgroundUploadExample