### PR TITLE
Fix untracable crashes when URL is not parsable

### DIFF
--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -156,9 +156,9 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
     @try {
         NSURL *requestUrl = [NSURL URLWithString: uploadUrl];
         if (requestUrl == nil) {
-            @throw @"Request cannot be nil";
+            return reject(@"RN Uploader", @"URL not compliant with RFC 2396", nil);
         }
-
+      
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:requestUrl];
         [request setHTTPMethod: method];
 


### PR DESCRIPTION
Due to NSURL checking compliance with RFC 2396 while parsing the url, sometimes when the URL is not compilant with the RFC it is considered `nil` and code throws this error. The problem is that this error is not caught anywhere, therefore crashing with a very unhelpful stack trace, as seen here: https://github.com/Vydia/react-native-background-upload/issues/121