### PR TITLE
Add iOS group app id support & fix .d.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Returns a promise with the string ID of the upload.  Will reject if there is a c
 |`parameters`|object|Optional||Additional form fields to include in the HTTP request. Only used when `type: 'multipart`||
 |`notification`|Notification object (see below)|Optional||Android only.  |`{ enabled: true, onProgressTitle: "Uploading...", autoClear: true }`|
 |`useUtf8Charset`|boolean|Optional||Android only. Set to true to use `utf-8` as charset. ||
+|`appGroup`|string|Optional|iOS only. App group ID needed for share extensions to be able to properly call the library. See: https://developer.apple.com/documentation/foundation/nsfilemanager/1412643-containerurlforsecurityapplicati
 
 ### Notification Object (Android Only)
 |Name|Type|Required|Description|Example|

--- a/index.d.ts
+++ b/index.d.ts
@@ -88,6 +88,11 @@ declare module "react-native-background-upload" {
         };
         // Android notification settings
         notification?: Partial<NotificationOptions>
+        /**
+         * AppGroup defined in XCode for extensions. Necessary when trying to upload things via this library
+         * in the context of ShareExtension.
+         */
+        appGroup?: string;
     }
 
     export interface MultipartUploadOptions extends UploadOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -93,6 +93,8 @@ declare module "react-native-background-upload" {
          * in the context of ShareExtension.
          */
         appGroup?: string;
+        // Necessary only for multipart type upload
+        field?: string
     }
 
     export interface MultipartUploadOptions extends UploadOptions {
@@ -107,13 +109,13 @@ declare module "react-native-background-upload" {
 
     export type UploadListenerEvent = 'progress' | 'error' | 'completed' | 'cancelled'
 
+
     export default class Upload {
-        static startUpload(options: UploadOptions): Promise<uploadId>
-        static addListener(event: UploadListenerEvent, uploadId: uploadId, data: object): void
-        static addListener(event: 'progress', uploadId: uploadId, data: ProgressData): void
-        static addListener(event: 'error', uploadId: uploadId, data: ErrorData): void
-        static addListener(event: 'completed', uploadId: uploadId, data: CompletedData): void
-        static addListener(event: 'cancelled', uploadId: uploadId, data: EventData): void
+        static startUpload(options: UploadOptions | MultipartUploadOptions): Promise<uploadId>
+        static addListener(event: 'progress', uploadId: uploadId, callback: (data: ProgressData ) => void): void
+        static addListener(event: 'error', uploadId: uploadId, callback: (data: ErrorData) => void): void
+        static addListener(event: 'completed', uploadId: uploadId, callback: (data: CompletedData) => void): void
+        static addListener(event: 'cancelled', uploadId: uploadId, callback: (data: EventData) => void): void
         static getFileInfo(path: string): Promise<FileInfo>
         static cancelUpload(uploadId: uploadId): Promise<boolean>
     }

--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -150,6 +150,7 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
     NSString *uploadType = options[@"type"] ?: @"raw";
     NSString *fieldName = options[@"field"];
     NSString *customUploadId = options[@"customUploadId"];
+    NSString *appGroup = options[@"appGroup"];
     NSDictionary *headers = options[@"headers"];
     NSDictionary *parameters = options[@"parameters"];
 
@@ -158,7 +159,7 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
         if (requestUrl == nil) {
             return reject(@"RN Uploader", @"URL not compliant with RFC 2396", nil);
         }
-      
+
         NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:requestUrl];
         [request setHTTPMethod: method];
 
@@ -197,14 +198,14 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
             NSData *httpBody = [self createBodyWithBoundary:uuidStr path:fileURI parameters: parameters fieldName:fieldName];
             [request setHTTPBody: httpBody];
 
-            uploadTask = [[self urlSession] uploadTaskWithStreamedRequest:request];
+            uploadTask = [[self urlSession: appGroup] uploadTaskWithStreamedRequest:request];
         } else {
             if (parameters.count > 0) {
                 reject(@"RN Uploader", @"Parameters supported only in multipart type", nil);
                 return;
             }
 
-            uploadTask = [[self urlSession] uploadTaskWithRequest:request fromFile:[NSURL URLWithString: fileURI]];
+            uploadTask = [[self urlSession: appGroup] uploadTaskWithRequest:request fromFile:[NSURL URLWithString: fileURI]];
         }
 
         uploadTask.taskDescription = customUploadId ? customUploadId : [NSString stringWithFormat:@"%i", thisUploadId];
@@ -266,9 +267,12 @@ RCT_EXPORT_METHOD(cancelUpload: (NSString *)cancelUploadId resolve:(RCTPromiseRe
     return httpBody;
 }
 
-- (NSURLSession *)urlSession {
+- (NSURLSession *)urlSession: (NSString *) groupId {
     if (_urlSession == nil) {
         NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:BACKGROUND_SESSION_ID];
+        if (groupId != nil && ![groupId isEqualToString:@""]) {
+            sessionConfiguration.sharedContainerIdentifier = groupId;
+        }
         _urlSession = [NSURLSession sessionWithConfiguration:sessionConfiguration delegate:self delegateQueue:nil];
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Add iOS group add id support & fix .d.ts

<!--
Explain the **motivation** for making this change: here are some points to help you:


* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
* Fixes #146 
This MR adds support to properly get and use group app id when provided via XCode configuration. It should automatically allow share extension or other extensions to use the library properly.
In addition to the above, second commit also fixes types for multipart upload.


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ X] I added the documentation in `README.md`
- [X ] I updated the typed files (TS and Flow)
- [ ] I've added Detox End-to-End Test(s)
- [ ] I've created a snack to demonstrate the changes: LINK HERE
