### PR TITLE
Fix non latin multipart file upload

### DIFF
--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -55,7 +55,10 @@ NSURLSession *_urlSession = nil;
 RCT_EXPORT_METHOD(getFileInfo:(NSString *)path resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 {
     @try {
-        NSURL *fileUri = [NSURL URLWithString: path];
+        // Escape non latin characters in filename
+        NSString *escapedPath = [path stringByAddingPercentEncodingWithAllowedCharacters: NSCharacterSet.URLQueryAllowedCharacterSet];
+       
+        NSURL *fileUri = [NSURL URLWithString:escapedPath];
         NSString *pathWithoutProtocol = [fileUri path];
         NSString *name = [fileUri lastPathComponent];
         NSString *extension = [name pathExtension];
@@ -242,11 +245,19 @@ RCT_EXPORT_METHOD(cancelUpload: (NSString *)cancelUploadId resolve:(RCTPromiseRe
 
     NSMutableData *httpBody = [NSMutableData data];
 
-    // resolve path
-    NSURL *fileUri = [NSURL URLWithString: path];
-    NSString *pathWithoutProtocol = [fileUri path];
+    // Escape non latin characters in filename
+    NSString *escapedPath = [path stringByAddingPercentEncodingWithAllowedCharacters: NSCharacterSet.URLQueryAllowedCharacterSet];
 
-    NSData *data = [[NSFileManager defaultManager] contentsAtPath:pathWithoutProtocol];
+    // resolve path
+    NSURL *fileUri = [NSURL URLWithString: escapedPath];
+    
+    NSError* error = nil;
+    NSData *data = [NSData dataWithContentsOfURL:fileUri options:NSDataReadingMappedAlways error: &error];
+
+    if (data == nil) {
+        NSLog(@"Failed to read file %@", error);
+    }
+
     NSString *filename  = [path lastPathComponent];
     NSString *mimetype  = [self guessMIMETypeFromFileName:path];
 


### PR DESCRIPTION
# Summary

Current implementation of multipart file upload and `getFileInfo` on iOS doesn't support file names with non latin characters.  This PR solves it. BTW, Android works fine with `useUtf8Charset: true`.


Uploading file with non latin characters in filename results in empty [NsData](https://github.com/Vydia/react-native-background-upload/blob/672959952768ca3c3602607a47db4b921355036e/ios/VydiaRNFileUploader.m#L249) and incorrect httpBody content.

To use non latin filenames you need to do 2 things:

1. **Escape filepath**

Original file path: `file:///private/var/mobile/Containers/Data/Application/A027BF30-70BE-4936-8233-08CED19F0B67/tmp/com.example.app-Inbox/Файл.pdf`

Escaped file path:  `file:///private/var/mobile/Containers/Data/Application/A027BF30-70BE-4936-8233-08CED19F0B67/tmp/com.example.app-Inbox/%D0%A4%D0%B0%D0%B9%D0%BB.pdf`

2. **Change method of loading file**

I've failed to use `NSFileManager contentsAtPath` as file loader, so I had to change it to `NSData dataWithContentsOfURL`. According to Apple iOS SDK comments, it's the preferred way to do it. I'm not an expert, so I'm open to other alternatives.



## Test Plan

### What's required for testing (prerequisites)?

Rename any pdf file on your iOS device to `Файл.pdf`

### What are the steps to reproduce (after prerequisites)?

Try to upload `Файл.pdf` with `uploadType='multipart'`. It will send incorrect http body.
Try to `getFileInfo` of `Файл.pdf`. It will return an error.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
