### PR TITLE
Support custom filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,12 @@ const options = {
   path: 'file://path/to/file%20on%20device.png',
   method: 'POST',
   field: 'uploaded_media',
+  customFilename: 'new_filename.png',
   type: 'multipart'
 }
 ```
 
-Note the `field` property is required for multipart uploads.
+Note the `field` property is required for multipart uploads. `customFilename` is optional, by default it will take filename from the path.
 
 # API
 
@@ -165,6 +166,7 @@ Returns a promise with the string ID of the upload.  Will reject if there is a c
 |`customUploadId`|string|Optional||`startUpload` returns a Promise that includes the upload ID, which can be used for future status checks.  By default, the upload ID is automatically generated.  This parameter allows a custom ID to use instead of the default.||
 |`headers`|object|Optional||HTTP headers|`{ 'Accept': 'application/json' }`|
 |`field`|string|Required if `type: 'multipart'`||The form field name for the file.  Only used when `type: 'multipart`|`uploaded-file`|
+|`customFilename`|string|Optional||Override the original filename with a custom name||
 |`parameters`|object|Optional||Additional form fields to include in the HTTP request. Only used when `type: 'multipart`||
 |`notification`|Notification object (see below)|Optional||Android only.  |`{ enabled: true, onProgressTitle: "Uploading...", autoClear: true }`|
 |`useUtf8Charset`|boolean|Optional||Android only. Set to true to use `utf-8` as charset. ||

--- a/android/src/main/java/com/vydia/UploaderModule.java
+++ b/android/src/main/java/com/vydia/UploaderModule.java
@@ -139,6 +139,16 @@ public class UploaderModule extends ReactContextBaseJavaModule implements Lifecy
       }
     }
 
+    String customFilename = null;
+
+    if (options.hasKey("customFilename")) {
+      customFilename = options.getString("customFilename");
+      if (customFilename == null) {
+        promise.reject(new IllegalArgumentException("type must be string."));
+        return;
+      }
+    }
+
     WritableMap notification = new WritableNativeMap();
     notification.putBoolean("enabled", true);
 
@@ -178,10 +188,10 @@ public class UploaderModule extends ReactContextBaseJavaModule implements Lifecy
         if(options.hasKey("useUtf8Charset") && options.getBoolean("useUtf8Charset")) {
           request = new MultipartUploadRequest(this.getReactApplicationContext(), customUploadId, url)
             .setUtf8Charset()
-            .addFileToUpload(filePath, options.getString("field"));
+            .addFileToUpload(filePath, options.getString("field"), customFilename);
         } else {
           request = new MultipartUploadRequest(this.getReactApplicationContext(), customUploadId, url)
-            .addFileToUpload(filePath, options.getString("field"));
+            .addFileToUpload(filePath, options.getString("field"), customFilename);
         }
       }
 

--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -149,6 +149,7 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
     NSString *method = options[@"method"] ?: @"POST";
     NSString *uploadType = options[@"type"] ?: @"raw";
     NSString *fieldName = options[@"field"];
+    NSString *customFilename = options[@"customFilename"];
     NSString *customUploadId = options[@"customUploadId"];
     NSString *appGroup = options[@"appGroup"];
     NSDictionary *headers = options[@"headers"];
@@ -195,7 +196,7 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
             NSString *uuidStr = [[NSUUID UUID] UUIDString];
             [request setValue:[NSString stringWithFormat:@"multipart/form-data; boundary=%@", uuidStr] forHTTPHeaderField:@"Content-Type"];
 
-            NSData *httpBody = [self createBodyWithBoundary:uuidStr path:fileURI parameters: parameters fieldName:fieldName];
+            NSData *httpBody = [self createBodyWithBoundary:uuidStr path:fileURI parameters: parameters fieldName:fieldName customFilename:customFilename];
             [request setHTTPBody: httpBody];
 
             uploadTask = [[self urlSession: appGroup] uploadTaskWithStreamedRequest:request];
@@ -239,6 +240,14 @@ RCT_EXPORT_METHOD(cancelUpload: (NSString *)cancelUploadId resolve:(RCTPromiseRe
                          path:(NSString *)path
                          parameters:(NSDictionary *)parameters
                          fieldName:(NSString *)fieldName {
+   return [self createBodyWithBoundary:boundary path:path parameters:parameters fieldName:fieldName customFilename:nil];
+}
+
+- (NSData *)createBodyWithBoundary:(NSString *)boundary
+                         path:(NSString *)path
+                         parameters:(NSDictionary *)parameters
+                         fieldName:(NSString *)fieldName
+                         customFilename:(NSString *)customFilename {
 
     NSMutableData *httpBody = [NSMutableData data];
 
@@ -248,6 +257,9 @@ RCT_EXPORT_METHOD(cancelUpload: (NSString *)cancelUploadId resolve:(RCTPromiseRe
 
     NSData *data = [[NSFileManager defaultManager] contentsAtPath:pathWithoutProtocol];
     NSString *filename  = [path lastPathComponent];
+    if (customFilename != nil) {
+      filename = customFilename;
+    }
     NSString *mimetype  = [self guessMIMETypeFromFileName:path];
 
     [parameters enumerateKeysAndObjectsUsingBlock:^(NSString *parameterKey, NSString *parameterValue, BOOL *stop) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
The goal of the update is to allow using a custom file name in the upload request. Sometimes it is useful to use a different name from the original file name.

This update includes some logic in the native code (android/iOS) to use a custom file name at the time of creating the request.

Also, it includes a new setting in the uploader `{ customFilename: string }`. This PR also updates the README file.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
Just include the `customFilename` into the options.

```
const options = {
  url: 'https://myservice.com/path/to/post',
  path: 'file://path/to/file%20on%20device.png',
  method: 'POST',
  field: 'uploaded_media',
  customFilename: 'new_filename.png',
  type: 'multipart'
}
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅    |

