### PR TITLE
Video uploads larger than ~100MB fail on iOS

### DIFF
--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -199,7 +199,8 @@ RCT_EXPORT_METHOD(startUpload:(NSDictionary *)options resolve:(RCTPromiseResolve
             [request setValue:[NSString stringWithFormat:@"multipart/form-data; boundary=%@", uuidStr] forHTTPHeaderField:@"Content-Type"];
 
             NSData *httpBody = [self createBodyWithBoundary:uuidStr path:fileURI parameters: parameters fieldName:fieldName];
-            [request setHTTPBody: httpBody];
+            [request setHTTPBodyStream: [NSInputStream inputStreamWithData:httpBody]];
+            [request setValue:[NSString stringWithFormat:@"%zd", httpBody.length] forHTTPHeaderField:@"Content-Length"];
 
             uploadTask = [[self urlSession: appGroup] uploadTaskWithStreamedRequest:request];
         } else {
@@ -351,6 +352,17 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
         _responsesData[@(dataTask.taskIdentifier)] = responseData;
     } else {
         [responseData appendData:data];
+    }
+}
+
+- (void)URLSession:(NSURLSession *)session
+              task:(NSURLSessionTask *)task
+ needNewBodyStream:(void (^)(NSInputStream *bodyStream))completionHandler {
+
+    NSInputStream *inputStream = task.originalRequest.HTTPBodyStream;
+
+    if (completionHandler) {
+        completionHandler(inputStream);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-background-upload",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "Cross platform http post file uploader with android and iOS background support",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
# Summary
* What issues does the pull request solve? *
#172 
#149 
#53 
#93 

## Test Plan
Large files to upload as a multipart. Size limit depends on device type, tested well with even over 2gb files. Without these changes, it's failing around 100mb.

### What's required for testing (prerequisites)?
Prepare large file (f.e. 1gb video file)
Prepare remote server for uploading.

### What are the steps to reproduce (after prerequisites)?
Try to upload large file as a multipart to your remote server with success.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I've added Detox End-to-End Test(s)
- [ ] I've created a snack to demonstrate the changes: LINK HERE
