### PR TITLE
Return headers on successful response

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Event Data
 |`id`|string|Required|The ID of the upload.|
 |`responseCode`|string|Required|HTTP status code received|
 |`responseBody`|string|Required|HTTP response body|
+|`responseHeaders`|string|Required|HTTP response headers (Android)|
 
 ### cancelled
 

--- a/android/src/main/java/com/vydia/RNUploader/GlobalRequestObserverDelegate.kt
+++ b/android/src/main/java/com/vydia/RNUploader/GlobalRequestObserverDelegate.kt
@@ -22,7 +22,6 @@ class GlobalRequestObserverDelegate(reactContext: ReactApplicationContext) : Req
   }
 
   override fun onError(context: Context, uploadInfo: UploadInfo, exception: Throwable) {
-
     val params = Arguments.createMap()
     params.putString("id", uploadInfo.uploadId)
 
@@ -45,10 +44,15 @@ class GlobalRequestObserverDelegate(reactContext: ReactApplicationContext) : Req
   }
 
   override fun onSuccess(context: Context, uploadInfo: UploadInfo, serverResponse: ServerResponse) {
+    val headers = Arguments.createMap()
+    for ((key, value) in serverResponse.headers) {
+      headers.putString(key, value)
+    }
     val params = Arguments.createMap()
     params.putString("id", uploadInfo.uploadId)
     params.putInt("responseCode", serverResponse.code)
     params.putString("responseBody", serverResponse.bodyString)
+    params.putMap("responseHeaders", headers)
     sendEvent("completed", params, context)
   }
 


### PR DESCRIPTION
…esful responses along with params value

# Summary

We're performing multipart uploads to s3, once all parts are uploaded we need to let aws know that the file is ready to be put back together by sending back all header values for each part uploaded.  Having access to headers helps us to be able to let aws know past files have been successfully uploaded.

This is a simple change that is changes androids `GlobalRequestObserverDelegate`

We've been testing this simple update and have had good success with it, we believe it might be helpful for others.

| OS      | Implemented |
| Android |    ✅     |

## Checklist


- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I've added Detox End-to-End Test(s)
- [ ] I've created a snack to demonstrate the changes: LINK HERE
