### PR TITLE
Android feature: multiple files upload in one shot via multipart, issue #240

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,25 @@ const options = {
 
 Note the `field` property is required for multipart uploads.
 
+## Android only, multiple files upload in one shot via Multipart
+
+Send all the files in `files` param. In this case `path`, `field` & `type` will be ignored.  Example:
+
+```
+const options = {
+  url: 'https://myservice.com/path/to/post',
+  files: [
+    {
+      path: 'file://path/to/file%20on%20device.png',
+      field: 'uploaded_media'
+    }
+  ],
+  method: 'POST'
+}
+```
+
+Note that `type` will always be multipart when `files` is passed
+
 # API
 
 ## Top Level Functions
@@ -160,6 +179,7 @@ Returns a promise with the string ID of the upload.  Will reject if there is a c
 |---|---|---|---|---|---|
 |`url`|string|Required||URL to upload to|`https://myservice.com/path/to/post`|
 |`path`|string|Required||File path on device|`file://something/coming/from%20the%20device.png`|
+|`files`|array|Optional||Android only, to upload multiple files in one request|`[{path: 'file://path/to/file%20on%20device.png', field: 'uploaded_media'}, {path: '', field: ''}]`
 |`type`|'raw' or 'multipart'|Optional|`raw`|Primary upload type.||
 |`method`|string|Optional|`POST`|HTTP method||
 |`customUploadId`|string|Optional||`startUpload` returns a Promise that includes the upload ID, which can be used for future status checks.  By default, the upload ID is automatically generated.  This parameter allows a custom ID to use instead of the default.||
@@ -304,7 +324,9 @@ Does it support iOS camera roll assets?
 
 Does it support multiple file uploads?
 
-> Yes and No.  It supports multiple concurrent uploads, but only a single upload per request.  That should be fine for 90%+ of cases.
+> Android: Yes, both multiple concurrent uploads as well as multiple files in one request are supported.
+
+> ios: Yes and No.  It supports multiple concurrent uploads, but only a single upload per request.  That should be fine for 90%+ of cases.
 
 Why should I use this file uploader instead of others that I've Googled like [react-native-uploader](https://github.com/aroth/react-native-uploader)?
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -81,6 +81,15 @@ declare module "react-native-background-upload" {
     export interface UploadOptions {
         url: string;
         path: string;
+        /**
+        * Android only, to upload multiple files in one request via multipart
+        * `path` & `field` will be ignored and `type` will be multipart if `files` is available
+        */
+        files?: {
+          path: string;
+          // Fallback to file0, file1, file2 etc
+          field?: string;
+        };
         type?: 'raw' | 'multipart';
         method?: 'POST' | 'GET' | 'PUT' | 'PATCH' | 'DELETE';
         customUploadId?: string;


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Android only support for uploading multiple files in one go
Issue: https://github.com/Vydia/react-native-background-upload/issues/240

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

```
const onChooseImagesPress = () => {
  launchImageLibrary({
    selectionLimit: 20
  }, ({assets}) => {
    const uploadConfig = {
      url: 'https://httpbin.org/post',
      //type: 'multipart',
      method: 'POST',
      notification: {
        enabled: true
      },
      useUtf8Charset: true
    };
    startUpload({
      ...uploadConfig,
      files: assets.map(asset => ({
        path: asset.uri.substr(7),
        field: asset.fileName
      }))
    })
  });
};
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on an emulator
- [X] I added the documentation in `README.md`
- [X] I updated the typed files (TS only)
- [ ] I've added Detox End-to-End Test(s)
- [ ] I've created a snack to demonstrate the changes: LINK HERE
