### PR TITLE
fix: check if UTI exists

### DIFF
--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -91,7 +91,11 @@ RCT_EXPORT_METHOD(getFileInfo:(NSString *)path resolve:(RCTPromiseResolveBlock)r
 - (NSString *)guessMIMETypeFromFileName: (NSString *)fileName {
     CFStringRef UTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)[fileName pathExtension], NULL);
     CFStringRef MIMEType = UTTypeCopyPreferredTagWithClass(UTI, kUTTagClassMIMEType);
-    CFRelease(UTI);
+    
+    if (UTI) {
+        CFRelease(UTI);
+    }
+  
     if (!MIMEType) {
         return @"application/octet-stream";
     }


### PR DESCRIPTION
Fixes a crash if UTI is null on Mac M1 simulators:

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Solves a crash on startUpload method when testing on Mac M1 iPhone Simulator, more info on already existing pull request (https://github.com/invertase/react-native-firebase/issues/4661)

### What's required for testing (prerequisites)?

Apple Mac M1 series

### What are the steps to reproduce (after prerequisites)?

Any call to Upload.startUpload crashes on iOS simulator.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I've added Detox End-to-End Test(s)
- [ ] I've created a snack to demonstrate the changes: LINK HERE
