### PR TITLE
Update net.gotev:uploadservice-okhttp latest

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,7 +64,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:$_kotlinStdlib:$_kotlinVersion"
 
-    implementation 'net.gotev:uploadservice-okhttp:4.3.0'
+    implementation 'net.gotev:uploadservice-okhttp:4.6.0'
 
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
This PR will continue the effort of moving away from jcenter #244.
Currently, in mavenCentral, there is no version net.gotev:uploadservice-okhttp:4.3.0 
Reference here: https://search.maven.org/artifact/net.gotev/uploadservice-okhttp

# Solution
- Upgrade to the latest version (4.6.0)

