### PR TITLE
fixes crash in android 11

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,7 +64,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:$_kotlinStdlib:$_kotlinVersion"
 
-    implementation 'net.gotev:uploadservice-okhttp:4.6.0'
+    implementation 'net.gotev:uploadservice-okhttp:4.7.0'
 
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
 }


### PR DESCRIPTION
# Summary
This PR fixes crash happening in android 11 device due to lower version of 'net.gotev:uploadservice-okhttp' dependency.

linked issue #288