### PR TITLE
Siiiiilvio patch 1

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,10 +14,13 @@ declare module "react-native-background-upload" {
     }
 
     export interface CompletedData extends EventData {
-
         responseCode: number
         responseBody: string
+        responseHeaders: {
++         [key: string]: string
++       }
     }
+    
     export type FileInfo = {
         name: string
         exists: boolean

--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -306,6 +306,7 @@ didCompleteWithError:(NSError *)error {
     if (response != nil)
     {
         [data setObject:[NSNumber numberWithInteger:response.statusCode] forKey:@"responseCode"];
+        [data setObject:response.allHeaderFields forKey:@"responseHeaders"];
     }
     //Add data that was collected earlier by the didReceiveData method
     NSMutableData *responseData = _responsesData[@(task.taskIdentifier)];


### PR DESCRIPTION
# Summary

When using your this library with your own multipart uploader, you may need some additional information from the response such as Etag headers from Amazon S3.

## Test Plan

When the response is valid, populate the responseHeaders with the response headers using allHeaderFields.

### What's required for testing (prerequisites)?

Test completed, cancelled and error scenarios.

### What are the steps to reproduce (after prerequisites)?

When upload is completed, inspect the data object with the nested responseHeaders object.

## Compatibility

| iOS        |    ✅          
| Android |    ✅ (Already implemented by https://github.com/Vydia/react-native-background-upload/pull/265)

## Checklist

- [ X ] I have tested this on a device and a simulator
- [ X ] I added the documentation in `README.md`
- [ X ] I updated the typed files (TS and Flow)
- [ ] I've added Detox End-to-End Test(s)
- [ ] I've created a snack to demonstrate the changes: LINK HERE
