### PR TITLE
Upgrade Kotlin version to 1.6

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        kotlinVersion = '1.4.0'
+        kotlinVersion = '1.6.0'
         buildToolsVersion = '29.0.2'
         compileSdkVersion = 29
         targetSdkVersion = 29


### PR DESCRIPTION
# Summary

Upgrade kotlin version to mismatch version when build on RN > 0.69. It fixes the error of issue #309 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I've added Detox End-to-End Test(s)
- [ ] I've created a snack to demonstrate the changes: LINK HERE
