### PR TITLE
Add multipart file upload for iOS

### DIFF
--- a/ios/VydiaRNFileUploader.m
+++ b/ios/VydiaRNFileUploader.m
@@ -1,4 +1,3 @@
-
 #import <Foundation/Foundation.h>
 #import <MobileCoreServices/MobileCoreServices.h>
 #import <React/RCTEventEmitter.h>
@@ -440,11 +439,6 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
     if (completionHandler) {
         completionHandler(inputStream);
     }
-}
-
-
--(void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session {
-
 }
 
 @end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

This PR proposes a fix to problem when file uploads restarts completely when iOS app comes back from `background` state.

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you: -->

Added functions that will split files in part and safely check and save them on disk, and when starting again the remains of previous multipart files will be removed from disk to prevent unnecessary disk usage.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I've added Detox End-to-End Test(s)
- [ ] I've created a snack to demonstrate the changes: LINK HERE
