### PR TITLE
feat(android): Return response code and body when error on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ Event Data
 |---|---|---|---|
 |`id`|string|Required|The ID of the upload.|
 |`error`|string|Required|Error message.|
+|`responseCode`|string|Optional|HTTP status code received (Android)|
+|`responseBody`|string|Optional|HTTP response body (Android)|
 
 ### completed
 

--- a/android/src/main/java/com/vydia/RNUploader/GlobalRequestObserverDelegate.kt
+++ b/android/src/main/java/com/vydia/RNUploader/GlobalRequestObserverDelegate.kt
@@ -9,6 +9,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEm
 import net.gotev.uploadservice.data.UploadInfo
 import net.gotev.uploadservice.network.ServerResponse
 import net.gotev.uploadservice.observer.request.RequestObserverDelegate
+import net.gotev.uploadservice.exceptions.UploadError
 
 class GlobalRequestObserverDelegate(reactContext: ReactApplicationContext) : RequestObserverDelegate {
   private val TAG = "UploadReceiver"
@@ -28,6 +29,10 @@ class GlobalRequestObserverDelegate(reactContext: ReactApplicationContext) : Req
     // Make sure we do not try to call getMessage() on a null object
     if (exception != null) {
       params.putString("error", exception.message)
+      if (exception is UploadError) {
+        params.putInt("responseCode", exception.serverResponse.code)
+        params.putString("responseBody", String(exception.serverResponse.body, Charsets.US_ASCII))
+      }
     } else {
       params.putString("error", "Unknown exception")
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,8 @@ declare module "react-native-background-upload" {
 
     export interface ErrorData extends EventData {
         error: string
+        responseCode?: number
+        responseBody?: string
     }
 
     export interface CompletedData extends EventData {


### PR DESCRIPTION
# Summary

When there was an error, plugin would just return "upload error". Now, if it is an upload error, plugin return also the response code and body. This enable user to add custom behavior when receiving an upload error depending on the server.

This PR is just forwarding response code and body from android-upload-service.

## Test Plan

### What's required for testing (prerequisites)?

A server that return a 4XX.

### What are the steps to reproduce (after prerequisites)?

Create an upload which should fail with a 4XX. Check that the errorData contains responseCode and responseBody.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on ~~a device and~~ a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I've added Detox End-to-End Test(s)
- [ ] I've created a snack to demonstrate the changes
