### PR TITLE
fix: migrated from kotlin-android-extensions to kotlin-parcelize in a…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ buildscript {
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 
 def DEFAULT_COMPILE_SDK_VERSION = 28
 def DEFAULT_BUILD_TOOLS_VERSION = "28.0.3"


### PR DESCRIPTION
fix(android): removed kotlin-android-extensions plugin from build.gradle for compatibility with latest AGP and Kotlin

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This pull request removes the deprecated `kotlin-android-extensions` plugin from `android/build.gradle`.

**Motivation:**
- The plugin has been deprecated and removed in recent versions of Kotlin and AGP.
- Its presence causes build failures in modern React Native projects targeting AGP 7.0+ and Kotlin 1.6+.

**What the PR does:**
- Removes `apply plugin: 'kotlin-android-extensions'`
- Adds `apply plugin: 'kotlin-parcelize'` to support `@Parcelize` if used
- Improves compatibility with modern Android build environments

**Impact:**
- Affects only Android build configuration
- No impact on JavaScript code or runtime behavior

## Test Plan

### What's required for testing (prerequisites)?
- React Native project using Kotlin >= 1.6.20 and AGP >= 7.0.0
- Forked and linked this updated package locally

### What are the steps to reproduce (after prerequisites)?
1. Link this forked version of the package
2. Run `npx react-native run-android`
3. Verify that the app builds successfully
4. Confirm that upload functionality works as expected

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |     ❌      |
| Android |     ✅      |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I've added Detox End-to-End Test(s)
- [ ] I've created a snack to demonstrate the changes: N/A
